### PR TITLE
chore(rollup): group monaco chunks

### DIFF
--- a/packages/frontend/vite.config.js
+++ b/packages/frontend/vite.config.js
@@ -9,6 +9,12 @@ import { fileURLToPath } from 'url';
 let filename = fileURLToPath(import.meta.url);
 const PACKAGE_ROOT = path.dirname(filename);
 
+function manualChunks(id) {
+  if (id.includes('monaco-editor')) {
+    return 'monaco-editor';
+  }
+}
+
 // https://vitejs.dev/config/
 export default defineConfig({
   mode: process.env.MODE,
@@ -51,8 +57,14 @@ export default defineConfig({
     sourcemap: true,
     outDir: '../backend/media',
     assetsDir: '.',
-
+    modulePreload: false,
     emptyOutDir: true,
     reportCompressedSize: false,
+    rollupOptions: {
+      output: {
+        manualChunks: manualChunks,
+        inlineDynamicImports: false,
+      }
+    }
   },
 });


### PR DESCRIPTION
## Measure

1. Opening dev tools
2. Going to _Performance_ page
3. Click on _Record and Reload_

### **grouping monaco chunks**

| Test | Loading (ms) | Scripting (ms) | Rendering (ms) |
| --- | --- | --- | --- |
| 1 | 18 | 207 | 15 |
| 2 | 19 | 221 | 13 |
| 3 | 18 | 218 | 12 |
| 4 | 18 | 198 | 12 |
| 5 | 25 | 384 | 20 |
| 6 | 20 | 192 | 11 |
| 7 | 18 | 195 | 12 |
| avg | ~19 | ~230 | ~13 |

### **no grouping**

ℹ️ /packages/backend/media folder contains 191 files (a lot of chunks)

| Test | Loading (ms) | Scripting (ms) | Rendering (ms) |
| --- | --- | --- | --- |
| 1 | 27 | 107 | 12 |
| 2 | 28 | 111 | 12 |
| 3 | 25 | 110 | 13 |
| 4 | 23 | 415 | 16 |
| 5 | 26 | 118 | 14 |
| 6 | 29 | 116 | 13 |
| 7 | 26 | 137 | 12 |
| avg | ~26 | ~159 | ~13 |