### PR TITLE
chore: adding concurrency rule

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -19,6 +19,10 @@ name: pr-check
 
 on: [pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   lint-format-unit:
     name: linter, formatters and unit tests / ${{ matrix.os }}


### PR DESCRIPTION
Since we moved to the podman-desktop organisation, we share the workers for the github action