### PR TITLE
feat: better empty quadlet list page

### DIFF
--- a/packages/frontend/src/lib/empty-screen/EmptyQuadletList.spec.ts
+++ b/packages/frontend/src/lib/empty-screen/EmptyQuadletList.spec.ts
@@ -1,0 +1,119 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { fireEvent, render } from '@testing-library/svelte';
+import { expect, test, vi } from 'vitest';
+import EmptyQuadletList from '/@/lib/empty-screen/EmptyQuadletList.svelte';
+import * as connectionStore from '/@store/connections';
+import * as synchronisationStore from '/@store/synchronisation';
+
+import { readable } from 'svelte/store';
+import type { ProviderContainerConnectionDetailedInfo } from '/@shared/src/models/provider-container-connection-detailed-info';
+import type { SynchronisationInfo } from '/@shared/src/models/synchronisation';
+import type {} from 'svelte';
+
+// mock stores
+vi.mock('/@store/connections');
+vi.mock('/@store/synchronisation');
+
+// ui object
+const WSL_RUNNING_PROVIDER_DETAILED_INFO: ProviderContainerConnectionDetailedInfo = {
+  providerId: 'podman',
+  name: 'podman-machine',
+  vmType: 'WSL',
+  status: 'started',
+};
+
+const WSL_STOPPED_PROVIDER_DETAILED_INFO: ProviderContainerConnectionDetailedInfo = {
+  ...WSL_RUNNING_PROVIDER_DETAILED_INFO,
+  status: 'stopped',
+};
+
+const WSL_SYNCHRONISATION_INFO: SynchronisationInfo = {
+  connection: WSL_RUNNING_PROVIDER_DETAILED_INFO,
+  timestamp: Date.now(),
+};
+
+interface TestCase {
+  synchronisation: SynchronisationInfo[];
+  connections: ProviderContainerConnectionDetailedInfo[];
+  name: string;
+  message: string;
+}
+
+test.each([
+  {
+    synchronisation: [],
+    connections: [],
+    message: 'No running connection could be found',
+    name: 'no container connections should say no running connection could be found',
+  },
+  {
+    synchronisation: [],
+    connections: [WSL_STOPPED_PROVIDER_DETAILED_INFO],
+    message: 'No running connection could be found',
+    name: 'one stopped container connections should say no running connection could be found',
+  },
+  {
+    synchronisation: [],
+    connections: [WSL_RUNNING_PROVIDER_DETAILED_INFO],
+    message: 'Extension is out of sync',
+    name: 'one running container connections without synchronisation should say Extension is out of sync',
+  },
+  {
+    synchronisation: [WSL_SYNCHRONISATION_INFO],
+    connections: [WSL_RUNNING_PROVIDER_DETAILED_INFO],
+    message: 'No Quadlet found on the system',
+    name: 'one running container connections with synchronisation should say No Quadlet found on the system',
+  },
+])('$name', async ({ synchronisation, connections, message }: TestCase): Promise<void> => {
+  vi.mocked(connectionStore).providerConnectionsInfo = readable(connections);
+  vi.mocked(synchronisationStore).synchronisation = readable(synchronisation);
+
+  const { getByText } = render(EmptyQuadletList, {
+    refreshQuadlets: vi.fn(),
+  });
+
+  await vi.waitFor(() => {
+    const element = getByText(message);
+    expect(element).toBeDefined();
+  });
+});
+
+test('refresh button should call provider callback', async () => {
+  vi.mocked(connectionStore).providerConnectionsInfo = readable([WSL_RUNNING_PROVIDER_DETAILED_INFO]);
+  vi.mocked(synchronisationStore).synchronisation = readable([]);
+
+  const refreshMock = vi.fn();
+  const { getByRole } = render(EmptyQuadletList, {
+    refreshQuadlets: refreshMock,
+  });
+
+  const button = await vi.waitFor(() => {
+    const element = getByRole('button', { name: 'Refresh' });
+    expect(element).toBeDefined();
+    return element;
+  });
+  await fireEvent.click(button);
+
+  await vi.waitFor(() => {
+    expect(refreshMock).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/frontend/src/lib/empty-screen/EmptyQuadletList.svelte
+++ b/packages/frontend/src/lib/empty-screen/EmptyQuadletList.svelte
@@ -1,0 +1,64 @@
+<script lang="ts">
+import type { ProviderContainerConnectionDetailedInfo } from '/@shared/src/models/provider-container-connection-detailed-info';
+import { faArrowsRotate } from '@fortawesome/free-solid-svg-icons/faArrowsRotate';
+import { Button, EmptyScreen } from '@podman-desktop/ui-svelte';
+import { providerConnectionsInfo } from '/@store/connections';
+import { synchronisation } from '/@store/synchronisation';
+
+interface Props {
+  connection?: ProviderContainerConnectionDetailedInfo;
+  loading?: boolean;
+  // actions
+  refreshQuadlets: () => void;
+}
+
+let { connection, loading, refreshQuadlets }: Props = $props();
+
+let runningConnection: number = $derived(
+  $providerConnectionsInfo.reduce((accumulator, connection) => {
+    if (connection.status === 'started') return ++accumulator;
+    return accumulator;
+  }, 0),
+);
+
+let outOfSync: boolean = $derived.by(() => {
+  // if no connection selected check we have existing synchronisation
+  if (!connection) return $synchronisation.length === 0 && $providerConnectionsInfo.length > 0;
+
+  // if connection is not started we cannot sync
+  if (connection.status !== 'started') return false;
+
+  // if connection is started let's check for previous synchronisation
+  return !$synchronisation.find(provider => provider.connection === connection);
+});
+
+let message: string = $derived.by(() => {
+  if (runningConnection === 0) {
+    return 'No running connection could be found';
+  }
+
+  if (outOfSync) {
+    return 'Extension is out of sync';
+  }
+
+  // if selected connection but not started
+  if (connection && connection.status !== 'started') {
+    return `machine ${connection.name} is not running`;
+  }
+
+  return 'No Quadlet found on the system';
+});
+</script>
+
+<EmptyScreen icon={faArrowsRotate} title={'No Quadlets'} message={message}>
+  {#if outOfSync}
+    <div class="flex flex-col">
+      <Button
+        icon={faArrowsRotate}
+        inProgress={loading}
+        disabled={loading}
+        title="Refresh Quadlets"
+        on:click={refreshQuadlets}>Refresh</Button>
+    </div>
+  {/if}
+</EmptyScreen>

--- a/packages/frontend/src/pages/QuadletsList.svelte
+++ b/packages/frontend/src/pages/QuadletsList.svelte
@@ -1,13 +1,5 @@
 <script lang="ts">
-import {
-  Button,
-  Table,
-  TableColumn,
-  TableRow,
-  NavPage,
-  TableSimpleColumn,
-  EmptyScreen,
-} from '@podman-desktop/ui-svelte';
+import { Button, Table, TableColumn, TableRow, NavPage, TableSimpleColumn } from '@podman-desktop/ui-svelte';
 import type { QuadletInfo } from '/@shared/src/models/quadlet-info';
 import QuadletStatus from '../lib/table/QuadletStatus.svelte';
 import { quadletAPI } from '../api/client';
@@ -21,7 +13,7 @@ import type { ProviderContainerConnectionDetailedInfo } from '/@shared/src/model
 import { faCode } from '@fortawesome/free-solid-svg-icons/faCode';
 import MachineBadge from '/@/lib/table/MachineBadge.svelte';
 import type { ProviderContainerConnectionIdentifierInfo } from '/@shared/src/models/provider-container-connection-identifier-info';
-import { synchronisation } from '/@store/synchronisation';
+import EmptyQuadletList from '/@/lib/empty-screen/EmptyQuadletList.svelte';
 
 const columns = [
   new TableColumn<QuadletInfo>('Status', { width: '70px', renderer: QuadletStatus, align: 'center' }),
@@ -79,18 +71,6 @@ let data: (QuadletInfo & { selected?: boolean })[] = $derived(
 
 let empty: boolean = $derived(data.length === 0);
 
-let outOfSync: boolean = $derived.by(() => {
-  // check if synchronisation is out
-  if (containerProviderConnection) {
-    return (
-      !$synchronisation.find(provider => provider.connection === containerProviderConnection) &&
-      containerProviderConnection.status === 'started'
-    );
-  } else {
-    return $synchronisation.length === 0 && $providerConnectionsInfo.length > 0;
-  }
-});
-
 function navigateToGenerate(): void {
   router.goto('/quadlets/generate');
 }
@@ -120,21 +100,7 @@ function navigateToGenerate(): void {
     {#if !empty}
       <Table kind="service" data={data} columns={columns} row={row} />
     {:else}
-      <EmptyScreen
-        icon={faArrowsRotate}
-        title={'No Quadlet found on the system'}
-        message={outOfSync ? 'Extension is out of sync' : 'Try creating a quadlet'}>
-        {#if outOfSync}
-          <div class="flex flex-col">
-            <Button
-              icon={faArrowsRotate}
-              inProgress={loading}
-              disabled={loading}
-              title="Refresh Quadlets"
-              on:click={refreshQuadlets}>Refresh</Button>
-          </div>
-        {/if}
-      </EmptyScreen>
+      <EmptyQuadletList connection={containerProviderConnection} refreshQuadlets={refreshQuadlets} loading={loading} />
     {/if}
   </svelte:fragment>
 </NavPage>


### PR DESCRIPTION
Specify that the selected container engine is not running (if it is not)

![image](https://github.com/user-attachments/assets/ae1bf43c-5c25-4436-94cc-2931716b5441)

Specify that no container engines is running (if none are running)

![image](https://github.com/user-attachments/assets/51085747-bf9a-4fb5-9ebb-e3a4b4621f45)
