### PR TITLE
chore: bump @podman-desktop/* to 1.16.0

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -63,8 +63,8 @@
     ]
   },
   "devDependencies": {
-    "@podman-desktop/api": "^1.15.0",
-    "@podman-desktop/podman-extension-api": "next",
+    "@podman-desktop/api": "^1.16.0",
+    "@podman-desktop/podman-extension-api": "^1.16.0",
     "@types/node": "^20",
     "@types/tar-fs": "^2.0.4",
     "@types/unzipper": "^0.10.10",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -26,7 +26,7 @@
     "@fortawesome/free-brands-svg-icons": "^6.7.2",
     "@fortawesome/free-regular-svg-icons": "^6.7.2",
     "@fortawesome/free-solid-svg-icons": "^6.7.2",
-    "@podman-desktop/ui-svelte": "^1.15.0-202412031339-936cb90e72b",
+    "@podman-desktop/ui-svelte": "^1.16.0",
     "@sveltejs/vite-plugin-svelte": "5.0.3",
     "@tailwindcss/typography": "^0.5.16",
     "@testing-library/dom": "^10.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,7 +35,7 @@ importers:
         version: 9.19.0(jiti@1.21.6)
       eslint-import-resolver-custom-alias:
         specifier: ^1.3.2
-        version: 1.3.2(eslint-plugin-import@2.31.0)
+        version: 1.3.2(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.21.0(eslint@9.19.0(jiti@1.21.6))(typescript@5.7.3))(eslint-import-resolver-typescript@3.7.0)(eslint@9.19.0(jiti@1.21.6)))
       eslint-import-resolver-typescript:
         specifier: ^3.7.0
         version: 3.7.0(eslint-plugin-import@2.31.0)(eslint@9.19.0(jiti@1.21.6))
@@ -116,11 +116,11 @@ importers:
         version: 0.11.6
     devDependencies:
       '@podman-desktop/api':
-        specifier: ^1.15.0
-        version: 1.15.0
+        specifier: ^1.16.0
+        version: 1.16.0
       '@podman-desktop/podman-extension-api':
-        specifier: next
-        version: 1.17.0-202501241426-5b789b34941
+        specifier: ^1.16.0
+        version: 1.16.0
       '@types/js-yaml':
         specifier: ^4.0.9
         version: 4.0.9
@@ -183,8 +183,8 @@ importers:
         specifier: ^6.7.2
         version: 6.7.2
       '@podman-desktop/ui-svelte':
-        specifier: ^1.15.0-202412031339-936cb90e72b
-        version: 1.15.0-202412031339-936cb90e72b(svelte-fa@4.0.3(svelte@5.19.3))(svelte@5.19.3)
+        specifier: ^1.16.0
+        version: 1.16.0(svelte-fa@4.0.3(svelte@5.19.3))(svelte@5.19.3)
       '@sveltejs/vite-plugin-svelte':
         specifier: 5.0.3
         version: 5.0.3(svelte@5.19.3)(vite@6.0.11(@types/node@20.17.16)(jiti@1.21.6)(yaml@2.6.1))
@@ -270,8 +270,8 @@ importers:
         specifier: ^1.49.1
         version: 1.49.1
       '@podman-desktop/tests-playwright':
-        specifier: 1.15.0
-        version: 1.15.0
+        specifier: 1.16.0
+        version: 1.16.0
       '@types/node':
         specifier: ^20
         version: 20.17.16
@@ -1397,20 +1397,17 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  '@podman-desktop/api@1.15.0':
-    resolution: {integrity: sha512-rYI2Fh/fRfNKtZAIz3OCk3GITJq5+oNxgU4aYVRWmPaX4Y5TSQoGr30Wwu4MGy02IQp3KY18JNe9/msWUE1MJA==}
+  '@podman-desktop/api@1.16.0':
+    resolution: {integrity: sha512-ZgSN3oJkwzoz2oMBO77EA+7rugt7R7kL6JmVtq5siXrRqj2Nn9tj0KYMv/jzz9KhlaHI2/ELN0qLWLNFuvxu0Q==}
 
-  '@podman-desktop/api@1.17.0-202501241426-5b789b34941':
-    resolution: {integrity: sha512-LbPiW8QbwPbJlgcIHc49POwGN/+ng3Z++TMxnCc4S++Me2ieP0wfgL3eOb3B8ENreEHPDeDPio5viiBl2pa3eQ==}
+  '@podman-desktop/podman-extension-api@1.16.0':
+    resolution: {integrity: sha512-4WPJesH/ySVmaniWgQLAe8YHcwtdTZ7vT0GITAcZozBrvOWLPQBbef5+GcMN7RSHUELF+g/aSwO9/cdKpGLY2A==}
 
-  '@podman-desktop/podman-extension-api@1.17.0-202501241426-5b789b34941':
-    resolution: {integrity: sha512-mm0GFqbQwDBkxj0kJF3L2ZkkcmJVEU11FttKgnk+UlvxZ6lzxrTULcw1KAylxwkh1SX1mb3pm/aWBoduOIKycA==}
+  '@podman-desktop/tests-playwright@1.16.0':
+    resolution: {integrity: sha512-MoLkzYZQclc1h6XRNwKcI7SM97QlAaH/59xMdQfF6Fsoften+/eannLaqEwieD7G8JJV4iA/Fr7IBKc5nPWqgQ==}
 
-  '@podman-desktop/tests-playwright@1.15.0':
-    resolution: {integrity: sha512-lDNHSr6dKaECuqwtpjDJRX/2SYYvK3o6uTQv1lMzuG3+99C27MqjgBPMcCvCYhFCT7BQDMZ9nJxeMlQsa2rJUg==}
-
-  '@podman-desktop/ui-svelte@1.15.0-202412031339-936cb90e72b':
-    resolution: {integrity: sha512-A7K7K0Rr/6JucjqF17WYpbygfmDkphvDfGjq0vK/KJBkh5s3k7i1BXfxFKfjWltf2hcqVLHZIavHky/FM6gGHw==}
+  '@podman-desktop/ui-svelte@1.16.0':
+    resolution: {integrity: sha512-sNe4Gk/+3bQEhtrTSkN5zRSB/S2p0DGEOpHCeugfB6vz4xy1MLrG6xGsqDAV8CDSiT92tn0oTyyI6zposyKu5g==}
     peerDependencies:
       svelte: ^4.0.0 || ^5.0.0
       svelte-fa: ^4.0.0
@@ -5443,17 +5440,15 @@ snapshots:
     dependencies:
       playwright: 1.49.1
 
-  '@podman-desktop/api@1.15.0': {}
+  '@podman-desktop/api@1.16.0': {}
 
-  '@podman-desktop/api@1.17.0-202501241426-5b789b34941': {}
-
-  '@podman-desktop/podman-extension-api@1.17.0-202501241426-5b789b34941':
+  '@podman-desktop/podman-extension-api@1.16.0':
     dependencies:
-      '@podman-desktop/api': 1.17.0-202501241426-5b789b34941
+      '@podman-desktop/api': 1.16.0
 
-  '@podman-desktop/tests-playwright@1.15.0': {}
+  '@podman-desktop/tests-playwright@1.16.0': {}
 
-  '@podman-desktop/ui-svelte@1.15.0-202412031339-936cb90e72b(svelte-fa@4.0.3(svelte@5.19.3))(svelte@5.19.3)':
+  '@podman-desktop/ui-svelte@1.16.0(svelte-fa@4.0.3(svelte@5.19.3))(svelte@5.19.3)':
     dependencies:
       '@fortawesome/fontawesome-free': 6.7.2
       '@fortawesome/free-brands-svg-icons': 6.7.2
@@ -6541,7 +6536,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-custom-alias@1.3.2(eslint-plugin-import@2.31.0):
+  eslint-import-resolver-custom-alias@1.3.2(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.21.0(eslint@9.19.0(jiti@1.21.6))(typescript@5.7.3))(eslint-import-resolver-typescript@3.7.0)(eslint@9.19.0(jiti@1.21.6))):
     dependencies:
       eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.21.0(eslint@9.19.0(jiti@1.21.6))(typescript@5.7.3))(eslint-import-resolver-typescript@3.7.0)(eslint@9.19.0(jiti@1.21.6))
       glob-parent: 6.0.2
@@ -6571,7 +6566,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.21.0(eslint@9.19.0(jiti@1.21.6))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@9.19.0(jiti@1.21.6)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.21.0(eslint@9.19.0(jiti@1.21.6))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0)(eslint@9.19.0(jiti@1.21.6)))(eslint@9.19.0(jiti@1.21.6)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -6606,7 +6601,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.19.0(jiti@1.21.6)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.21.0(eslint@9.19.0(jiti@1.21.6))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@9.19.0(jiti@1.21.6))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.21.0(eslint@9.19.0(jiti@1.21.6))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0)(eslint@9.19.0(jiti@1.21.6)))(eslint@9.19.0(jiti@1.21.6))
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3

--- a/tests/playwright/package.json
+++ b/tests/playwright/package.json
@@ -11,7 +11,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@playwright/test": "^1.49.1",
-    "@podman-desktop/tests-playwright": "1.15.0",
+    "@podman-desktop/tests-playwright": "1.16.0",
     "@types/node": "^20",
     "electron": "^34.0.1",
     "typescript": "^5.7.3",


### PR DESCRIPTION
The e2e use the api version to define which podman-desktop should be downloaded to run the e2e.

https://github.com/podman-desktop/extension-podman-quadlet/blob/382771c28ad5ef0066d947e2dc48771485f696a3/.github/workflows/pr-check.yaml#L119-L123

So we need to update everything at once, otherwise tests will fail 