### PR TITLE
feat: support configuring unit path

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -66,8 +66,8 @@
       "properties": {
         "quadlet.unit-path":  {
           "type": "string",
-          "default": "/etc/containers/systemd/users/",
-          "enum": ["/etc/containers/systemd/users/", "~/.config/containers/systemd/"],
+          "default": "~/.config/containers/systemd/",
+          "enum": ["~/.config/containers/systemd/", "/etc/containers/systemd/users/"],
           "markdownDescription": "Podman unit search path"
         }
       }

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -60,7 +60,18 @@
         "command": "podlet.compose",
         "title": "Podlet: compose"
       }
-    ]
+    ],
+    "configuration": {
+      "title": "Quadlet",
+      "properties": {
+        "quadlet.unit-path":  {
+          "type": "string",
+          "default": "/etc/containers/systemd/users/",
+          "enum": ["/etc/containers/systemd/users/", "~/.config/containers/systemd/"],
+          "markdownDescription": "Podman unit search path"
+        }
+      }
+    }
   },
   "devDependencies": {
     "@podman-desktop/api": "^1.15.0",

--- a/packages/backend/src/extension.ts
+++ b/packages/backend/src/extension.ts
@@ -11,6 +11,7 @@ import {
   window,
   cli as cliApi,
   commands as commandsApi,
+  configuration as configurationApi,
 } from '@podman-desktop/api';
 import { MainService } from './services/main-service';
 
@@ -28,6 +29,7 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
     cliApi: cliApi,
     commandsApi: commandsApi,
     containers: containerEngine,
+    configurationApi: configurationApi,
   });
   return main.init();
 }

--- a/packages/backend/src/services/configuration-service.ts
+++ b/packages/backend/src/services/configuration-service.ts
@@ -1,0 +1,23 @@
+import type { configuration, Disposable } from '@podman-desktop/api';
+import { contributes } from '../../package.json';
+
+interface Dependencies {
+  configurationApi: typeof configuration;
+}
+
+export class ConfigurationService implements Disposable {
+  constructor(protected dependencies: Dependencies) {}
+
+  dispose(): void {}
+
+  protected getDefaultQuadletUnitPath(): string {
+    return contributes.configuration.properties['quadlet.unit-path'].default;
+  }
+
+  getUnitPath(): string {
+    return (
+      this.dependencies.configurationApi.getConfiguration('quadlet').get<string>('unit-path') ??
+      this.getDefaultQuadletUnitPath()
+    );
+  }
+}

--- a/packages/backend/src/services/main-service.ts
+++ b/packages/backend/src/services/main-service.ts
@@ -12,7 +12,7 @@ import type {
   window,
   cli as cliApi,
   containerEngine,
-  TelemetryLogger,
+  TelemetryLogger, configuration,
 } from '@podman-desktop/api';
 import { WebviewService } from './webview-service';
 import { RpcExtension } from '/@shared/src/messages/message-proxy';
@@ -42,6 +42,7 @@ import { ImageApi } from '/@shared/src/apis/image-api';
 import { LoggerService } from './logger-service';
 import { LoggerApiImpl } from '../apis/logger-api-impl';
 import { LoggerApi } from '/@shared/src/apis/logger-api';
+import { ConfigurationService } from './configuration-service';
 
 interface Dependencies {
   extensionContext: ExtensionContext;
@@ -53,6 +54,7 @@ interface Dependencies {
   cliApi: typeof cliApi;
   commandsApi: typeof commandsApi;
   containers: typeof containerEngine;
+  configurationApi: typeof configuration;
 }
 
 export class MainService implements Disposable, AsyncInit {
@@ -85,6 +87,11 @@ export class MainService implements Disposable, AsyncInit {
       webview: webview.getPanel().webview,
     });
     this.#disposables.push(loggerService);
+
+    const configuration = new ConfigurationService({
+      configurationApi: this.dependencies.configurationApi,
+    });
+    this.#disposables.push(configuration);
 
     // init IPC system
     const rpcExtension = new RpcExtension(webview.getPanel().webview);
@@ -156,6 +163,7 @@ export class MainService implements Disposable, AsyncInit {
       providers: providers,
       window: this.dependencies.window,
       telemetry: this.#telemetry,
+      configuration,
     });
     await quadletService.init();
     this.#disposables.push(quadletService);

--- a/packages/backend/src/services/main-service.ts
+++ b/packages/backend/src/services/main-service.ts
@@ -12,7 +12,8 @@ import type {
   window,
   cli as cliApi,
   containerEngine,
-  TelemetryLogger, configuration,
+  TelemetryLogger,
+  configuration,
 } from '@podman-desktop/api';
 import { WebviewService } from './webview-service';
 import { RpcExtension } from '/@shared/src/messages/message-proxy';

--- a/packages/backend/src/services/quadlet-helper.ts
+++ b/packages/backend/src/services/quadlet-helper.ts
@@ -9,6 +9,7 @@ import type { PodmanService } from './podman-service';
 import type { SystemdService } from './systemd-service';
 import type { ProviderService } from './provider-service';
 import type { ProviderContainerConnectionIdentifierInfo } from '/@shared/src/models/provider-container-connection-identifier-info';
+import type { ConfigurationService } from './configuration-service';
 
 export interface QuadletServiceDependencies {
   providers: ProviderService;
@@ -18,6 +19,7 @@ export interface QuadletServiceDependencies {
   systemd: SystemdService;
   window: typeof window;
   telemetry: TelemetryLogger;
+  configuration: ConfigurationService;
 }
 
 type ProviderIdentifier = `${string}:${string}`;

--- a/packages/backend/src/services/quadlet-service.ts
+++ b/packages/backend/src/services/quadlet-service.ts
@@ -318,7 +318,7 @@ export class QuadletService extends QuadletHelper implements Disposable, AsyncIn
             if (options.admin) {
               destination = joinposix('/etc/containers/systemd/', resource.filename);
             } else {
-              destination = joinposix('~/.config/containers/systemd/', resource.filename);
+              destination = joinposix(this.dependencies.configuration.getUnitPath(), resource.filename);
             }
 
             // 2. write the file


### PR DESCRIPTION
## Description

Allow user to configure unit path to save the quadlets

## Related issue

Fixes https://github.com/podman-desktop/extension-podman-quadlet/issues/219

> ⚠️ some unit path are for rootful vs rootless, need to check the impact.