### PR TITLE
feat: trying e2e cache (again)

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -206,8 +206,17 @@ jobs:
           echo "PD_VERSION=$PD_VERSION" >> $GITHUB_OUTPUT
           echo "Using @podman-desktop/api $PD_VERSION"
 
+      # Check cache for existing podman-desktop
+      - name: Cache Podman Desktop
+        id: cache-pd
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/podman-desktop
+          key: pd-${{ steps.pd-api-version.outputs.PD_VERSION }}-${{ runner.os }}
+
       # Download Podman Desktop repository based on version defined in package.json
       - name: Download Podman Desktop
+        if: steps.cache-pd.outputs.cache-hit != 'true'
         shell: bash
         env:
           PD_VERSION: ${{ steps.pd-api-version.outputs.PD_VERSION }}
@@ -225,6 +234,7 @@ jobs:
 
       # Install and build podman-desktop
       - name: Install pnpm deps and build Podman Desktop
+        if: steps.cache-pd.outputs.cache-hit != 'true'
         shell: bash
         working-directory: ${{ github.workspace }}/podman-desktop
         run: |

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -112,6 +112,8 @@ jobs:
       SKIP_INSTALLATION: true
       EXTENSION_PREINSTALLED: true
       PODMAN_DESKTOP_ARGS: ${{ github.workspace }}/podman-desktop
+      # by default playwright cache browsers binaries in ~/.cache/ms-playwright on Linux and %USERPROFILE%\AppData\Local\ms-playwright on Windows
+      PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/podman-desktop/pw-browsers
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Description 

Devising e2e test by 2, on windows going from 8m to 4m.

### How?

In this repository we do not use upstream version of Podman Desktop, we take the `@podman-desktop/api` version and download the corresponding archive.

Therefore for most of pr-check the workflow is the same 
1. Download podman desktop
2. Install Podman Desktop packages
3. Build Podman Desktop  

This 3 steps were taking half the time, let's cache them. (This is what this PR is adding).

The reason why https://github.com/podman-desktop/extension-podman-quadlet/pull/131 were failing is because I failed to understand that playwright was caching the browsers outside the repository. After getting this information, I configured it to cache inside the repo, so it is included in the cached archive.

## Related issue

Fixes https://github.com/podman-desktop/extension-podman-quadlet/issues/235