### PR TITLE
feat: adding kube yaml tab to details page for kube quadlets

### DIFF
--- a/packages/backend/src/apis/quadlet-api-impl.spec.ts
+++ b/packages/backend/src/apis/quadlet-api-impl.spec.ts
@@ -1,0 +1,76 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import { expect, test, vi, beforeEach } from 'vitest';
+import { QuadletApiImpl } from './quadlet-api-impl';
+import type { QuadletService } from '../services/quadlet-service';
+import type { SystemdService } from '../services/systemd-service';
+import type { PodmanService } from '../services/podman-service';
+import type { ProviderService } from '../services/provider-service';
+import type { LoggerService } from '../services/logger-service';
+import type { ProviderContainerConnection } from '@podman-desktop/api';
+import type { ProviderContainerConnectionIdentifierInfo } from '/@shared/src/models/provider-container-connection-identifier-info';
+
+const QUADLET_SERVICE: QuadletService = {
+  getKubeYAML: vi.fn(),
+} as unknown as QuadletService;
+const SYSTEMD_SERVICE: SystemdService = {} as unknown as SystemdService;
+const PODMAN_SERVICE: PodmanService = {} as unknown as PodmanService;
+const PROVIDER_SERVICE: ProviderService = {
+  getProviderContainerConnection: vi.fn(),
+} as unknown as ProviderService;
+const LOGGER_SERVICE: LoggerService = {} as unknown as LoggerService;
+
+const WSL_PROVIDER_CONNECTION_MOCK: ProviderContainerConnection = {
+  connection: {
+    type: 'podman',
+    vmType: 'WSL',
+    name: 'podman-machine-default',
+  },
+  providerId: 'podman',
+} as ProviderContainerConnection;
+
+const WSL_PROVIDER_IDENTIFIER: ProviderContainerConnectionIdentifierInfo = {
+  name: WSL_PROVIDER_CONNECTION_MOCK.connection.name,
+  providerId: WSL_PROVIDER_CONNECTION_MOCK.providerId,
+};
+
+beforeEach(() => {
+  vi.resetAllMocks();
+
+  vi.mocked(PROVIDER_SERVICE.getProviderContainerConnection).mockReturnValue(WSL_PROVIDER_CONNECTION_MOCK);
+});
+
+function getQuadletApiImpl(): QuadletApiImpl {
+  return new QuadletApiImpl({
+    quadlet: QUADLET_SERVICE,
+    systemd: SYSTEMD_SERVICE,
+    podman: PODMAN_SERVICE,
+    providers: PROVIDER_SERVICE,
+    loggerService: LOGGER_SERVICE,
+  });
+}
+
+test('QuadletApiImpl#getKubeYAML should propagate result from QuadletService#getKubeYAML', async () => {
+  vi.mocked(QUADLET_SERVICE.getKubeYAML).mockResolvedValue('dummy-yaml-content');
+
+  const api = getQuadletApiImpl();
+
+  const result = await api.getKubeYAML(WSL_PROVIDER_IDENTIFIER, 'dummy-quadlet-id');
+  expect(result).toStrictEqual('dummy-yaml-content');
+  expect(PROVIDER_SERVICE.getProviderContainerConnection).toHaveBeenCalledWith(WSL_PROVIDER_IDENTIFIER);
+});

--- a/packages/backend/src/apis/quadlet-api-impl.ts
+++ b/packages/backend/src/apis/quadlet-api-impl.ts
@@ -146,6 +146,15 @@ export class QuadletApiImpl extends QuadletApi {
     return this.dependencies.quadlet.getSynchronisationInfo();
   }
 
+  override async getKubeYAML(connection: ProviderContainerConnectionIdentifierInfo, id: string): Promise<string> {
+    const providerConnection = this.dependencies.providers.getProviderContainerConnection(connection);
+
+    return await this.dependencies.quadlet.getKubeYAML({
+      provider: providerConnection,
+      id: id,
+    });
+  }
+
   override async validate(content: string): Promise<QuadletCheck[]> {
     return new QuadletValidator().validate(content);
   }

--- a/packages/backend/src/models/quadlet.ts
+++ b/packages/backend/src/models/quadlet.ts
@@ -1,11 +1,14 @@
 /**
  * @author axel7083
  */
+import type { QuadletType } from '/@shared/src/utils/quadlet-type';
 
 export interface Quadlet {
   id: string;
   path: string;
-  // raw content of the service file
+  // raw content (generate) of the service file
   content: string;
   state: 'active' | 'inactive' | 'deleting' | 'unknown';
+  // type of quadlet
+  type: QuadletType;
 }

--- a/packages/backend/src/services/quadlet-service.spec.ts
+++ b/packages/backend/src/services/quadlet-service.spec.ts
@@ -254,7 +254,7 @@ describe('QuadletService#saveIntoMachine', () => {
     // expect yaml file to be created
     expect(PODMAN_SERVICE_MOCK.writeTextFile).toHaveBeenCalledWith(
       WSL_RUNNING_PROVIDER_CONNECTION_MOCK,
-      `~/.config/containers/systemd/foo.yaml`, // always the same (using node:path/posix)
+      `~/.config/containers/systemd/foo-kube.yaml`, // always the same (using node:path/posix)
       'foo: bar',
     );
   });

--- a/packages/backend/src/services/quadlet-service.spec.ts
+++ b/packages/backend/src/services/quadlet-service.spec.ts
@@ -98,6 +98,7 @@ const QUADLET_MOCK: Quadlet = {
   path: 'foo/bar',
   state: 'unknown',
   content: 'dummy-content',
+  type: QuadletType.CONTAINER,
 };
 
 const PROGRESS_REPORT: Progress<{ message?: string; increment?: number }> = {
@@ -282,6 +283,7 @@ describe('QuadletService#remove', () => {
     state: 'unknown',
     path: `config/quadlet-${index}.container`,
     content: 'dummy-content',
+    type: QuadletType.CONTAINER,
   }));
 
   beforeEach(() => {

--- a/packages/backend/src/services/quadlet-service.ts
+++ b/packages/backend/src/services/quadlet-service.ts
@@ -487,10 +487,7 @@ export class QuadletService extends QuadletHelper implements Disposable, AsyncIn
     }));
   }
 
-  async getKubeYAML(options: {
-                id: string;
-                provider: ProviderContainerConnection;
-              }): Promise<string> {
+  async getKubeYAML(options: { id: string; provider: ProviderContainerConnection }): Promise<string> {
     const quadlet = this.findQuadlet({
       provider: options.provider,
       id: options.id,
@@ -498,7 +495,8 @@ export class QuadletService extends QuadletHelper implements Disposable, AsyncIn
     if (!quadlet) throw new Error(`quadlet with id ${options.id} not found`);
 
     // assert quadlet type is kube.
-    if(quadlet.type !== QuadletType.KUBE) throw new Error(`cannot get kube yaml of non-kube quadlet: quadlet ${quadlet.id} type is ${quadlet.type}`);
+    if (quadlet.type !== QuadletType.KUBE)
+      throw new Error(`cannot get kube yaml of non-kube quadlet: quadlet ${quadlet.id} type is ${quadlet.type}`);
 
     // extract the yaml file from
     const { yaml } = new QuadletKubeParser(quadlet.content).parse();
@@ -506,14 +504,14 @@ export class QuadletService extends QuadletHelper implements Disposable, AsyncIn
     // found the absolute path of the yaml
     // the documentation says "The path, absolute or relative to the location of the unit file, to the Kubernetes YAML file to use."
     let target: string;
-    if(isAbsolute(yaml)) {
+    if (isAbsolute(yaml)) {
       target = yaml;
     } else {
       target = joinposix(dirname(quadlet.path), yaml);
     }
 
     // some security, only allow to read yaml / yml files.
-    if(!target.endsWith('.yaml') && !target.endsWith('.yml')) {
+    if (!target.endsWith('.yaml') && !target.endsWith('.yml')) {
       throw new Error(`quadlet ${quadlet.id} declared yaml file ${target}: invalid file format.`);
     }
 

--- a/packages/backend/src/services/quadlet-service.ts
+++ b/packages/backend/src/services/quadlet-service.ts
@@ -238,7 +238,7 @@ export class QuadletService extends QuadletHelper implements Disposable, AsyncIn
         console.warn(err);
         load(resource);
         return {
-          filename: `${basename}.yaml`,
+          filename: `${basename}-kube.yaml`,
           content: resource,
         };
       }

--- a/packages/backend/src/services/quadlet-service.ts
+++ b/packages/backend/src/services/quadlet-service.ts
@@ -10,12 +10,13 @@ import { QuadletDryRunParser } from '../utils/parsers/quadlet-dryrun-parser';
 import type { Quadlet } from '../models/quadlet';
 import type { QuadletInfo } from '/@shared/src/models/quadlet-info';
 import type { AsyncInit } from '../utils/async-init';
-import { join as joinposix, basename } from 'node:path/posix';
+import { join as joinposix, basename, dirname, isAbsolute } from 'node:path/posix';
 import { load } from 'js-yaml';
 import { QuadletTypeParser } from '../utils/parsers/quadlet-type-parser';
 import type { SynchronisationInfo } from '/@shared/src/models/synchronisation';
 import { TelemetryEvents } from '../utils/telemetry-events';
-import type { QuadletType } from '/@shared/src/utils/quadlet-type';
+import { QuadletType } from '/@shared/src/utils/quadlet-type';
+import { QuadletKubeParser } from '../utils/parsers/quadlet-kube-parser';
 
 export class QuadletService extends QuadletHelper implements Disposable, AsyncInit {
   #extensionsEventDisposable: Disposable | undefined;
@@ -484,6 +485,50 @@ export class QuadletService extends QuadletHelper implements Disposable, AsyncIn
       connection: this.fromSymbol(symbol),
       timestamp: timestamp,
     }));
+  }
+
+  async getKubeYAML(options: {
+                id: string;
+                provider: ProviderContainerConnection;
+              }): Promise<string> {
+    const quadlet = this.findQuadlet({
+      provider: options.provider,
+      id: options.id,
+    });
+    if (!quadlet) throw new Error(`quadlet with id ${options.id} not found`);
+
+    // assert quadlet type is kube.
+    if(quadlet.type !== QuadletType.KUBE) throw new Error(`cannot get kube yaml of non-kube quadlet: quadlet ${quadlet.id} type is ${quadlet.type}`);
+
+    // extract the yaml file from
+    const { yaml } = new QuadletKubeParser(quadlet.content).parse();
+
+    // found the absolute path of the yaml
+    // the documentation says "The path, absolute or relative to the location of the unit file, to the Kubernetes YAML file to use."
+    let target: string;
+    if(isAbsolute(yaml)) {
+      target = yaml;
+    } else {
+      target = joinposix(dirname(quadlet.path), yaml);
+    }
+
+    // some security, only allow to read yaml / yml files.
+    if(!target.endsWith('.yaml') && !target.endsWith('.yml')) {
+      throw new Error(`quadlet ${quadlet.id} declared yaml file ${target}: invalid file format.`);
+    }
+
+    try {
+      // read
+      const result = await this.dependencies.podman.readTextFile(options.provider, target);
+      return result;
+    } catch (err: unknown) {
+      console.error(`Something went wrong with readTextFile on ${target}`, err);
+      // check err is an RunError
+      if (!err || typeof err !== 'object' || !('exitCode' in err) || !('stderr' in err)) {
+        throw err;
+      }
+      throw new Error(`cannot read ${target}: ${err.stderr}`);
+    }
   }
 
   dispose(): void {

--- a/packages/backend/src/utils/parsers/quadlet-kube-parser.spec.ts
+++ b/packages/backend/src/utils/parsers/quadlet-kube-parser.spec.ts
@@ -1,0 +1,37 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { test, expect } from 'vitest';
+import { QuadletKubeParser } from './quadlet-kube-parser';
+
+const KUBE_QUADLET_EXAMPLE = `
+# example.kube
+[X-Kube]
+Yaml=/mnt/foo/bar.yaml
+
+[Unit]
+Wants=network-online.target
+After=network-online.target
+SourcePath=/home/user/.config/containers/systemd/nginx2.container
+RequiresMountsFor=%t/containers
+`;
+
+test('expect parser to properly extract Yaml path', () => {
+  const xkube = new QuadletKubeParser(KUBE_QUADLET_EXAMPLE).parse();
+  expect(xkube.yaml).toStrictEqual('/mnt/foo/bar.yaml');
+});

--- a/packages/backend/src/utils/parsers/quadlet-kube-parser.ts
+++ b/packages/backend/src/utils/parsers/quadlet-kube-parser.ts
@@ -1,0 +1,41 @@
+/**
+ * @author axel7083
+ */
+
+import { Parser } from './iparser';
+import { parse } from 'js-ini';
+
+export interface XKube {
+  yaml: string;
+}
+
+/**
+ * Utility class to extract the Yaml property of the generated systemd unit.
+ * The quadlet must be of type Kube.
+ */
+export class QuadletKubeParser extends Parser<string, XKube> {
+  constructor(
+    content: string,
+  ) {
+    super(content);
+  }
+
+  protected toXKube(kube: Record<string, string>): XKube {
+    if (!('Yaml' in kube)) throw new Error('missing Yaml in systemd unit section');
+
+    return {
+      yaml: kube['Yaml'],
+    };
+  }
+
+  override parse(): XKube {
+    const raw = parse(this.content, {
+      comment: ['#', ';'],
+    });
+    const unit = this.toXKube(raw['X-Kube'] as Record<string, string>);
+
+    return {
+      yaml: unit.yaml,
+    };
+  }
+}

--- a/packages/backend/src/utils/parsers/quadlet-kube-parser.ts
+++ b/packages/backend/src/utils/parsers/quadlet-kube-parser.ts
@@ -14,9 +14,7 @@ export interface XKube {
  * The quadlet must be of type Kube.
  */
 export class QuadletKubeParser extends Parser<string, XKube> {
-  constructor(
-    content: string,
-  ) {
+  constructor(content: string) {
     super(content);
   }
 

--- a/packages/backend/src/utils/parsers/quadlet-type-parser.spec.ts
+++ b/packages/backend/src/utils/parsers/quadlet-type-parser.spec.ts
@@ -1,0 +1,26 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { test, expect } from 'vitest';
+import { QuadletType } from '/@shared/src/utils/quadlet-type';
+import { QuadletTypeParser } from './quadlet-type-parser';
+
+test.each(Object.values(QuadletType))('parsing quadlet %s', (type: QuadletType) => {
+  const result = new QuadletTypeParser(`[${type}]\nfoo=bar`).parse();
+  expect(result).toStrictEqual(type);
+});

--- a/packages/backend/src/utils/parsers/quadlet-unit-parser.spec.ts
+++ b/packages/backend/src/utils/parsers/quadlet-unit-parser.spec.ts
@@ -4,6 +4,7 @@
 
 import { test, expect } from 'vitest';
 import { QuadletUnitParser } from './quadlet-unit-parser';
+import { QuadletType } from '/@shared/src/utils/quadlet-type';
 
 const CONTAINER_QUADLET_EXAMPLE = `
 # demo-quadlet.container
@@ -44,6 +45,7 @@ test('expect path to be properly extracted', async () => {
   expect(result).toStrictEqual(
     expect.objectContaining({
       path: '/home/user/.config/containers/systemd/nginx2.container',
+      type: QuadletType.CONTAINER,
     }),
   );
 });

--- a/packages/backend/src/utils/parsers/quadlet-unit-parser.ts
+++ b/packages/backend/src/utils/parsers/quadlet-unit-parser.ts
@@ -35,7 +35,7 @@ export class QuadletUnitParser extends Parser<string, Quadlet> {
 
     const extension = unit.SourcePath.split('.').pop();
     const type: QuadletType | undefined = Object.values(QuadletType).find(type => extension === type.toLowerCase());
-    if(!type) throw new Error(`cannot found quadlet type for file ${unit.SourcePath}`);
+    if (!type) throw new Error(`cannot found quadlet type for file ${unit.SourcePath}`);
 
     return {
       path: unit.SourcePath,

--- a/packages/backend/src/utils/parsers/quadlet-unit-parser.ts
+++ b/packages/backend/src/utils/parsers/quadlet-unit-parser.ts
@@ -5,6 +5,7 @@
 import { Parser } from './iparser';
 import { parse } from 'js-ini';
 import type { Quadlet } from '../../models/quadlet';
+import { QuadletType } from '/@shared/src/utils/quadlet-type';
 
 interface Unit {
   SourcePath: string;
@@ -32,11 +33,16 @@ export class QuadletUnitParser extends Parser<string, Quadlet> {
     });
     const unit = this.toUnit(raw['Unit'] as Record<string, string>);
 
+    const extension = unit.SourcePath.split('.').pop();
+    const type: QuadletType | undefined = Object.values(QuadletType).find(type => extension === type.toLowerCase());
+    if(!type) throw new Error(`cannot found quadlet type for file ${unit.SourcePath}`);
+
     return {
       path: unit.SourcePath,
       id: this.serviceName,
       content: this.content,
       state: 'unknown',
+      type: type,
     };
   }
 }

--- a/packages/frontend/src/lib/monaco-editor/KubeYamlEditor.spec.ts
+++ b/packages/frontend/src/lib/monaco-editor/KubeYamlEditor.spec.ts
@@ -1,0 +1,139 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, fireEvent } from '@testing-library/svelte';
+import { beforeEach, test, vi, expect } from 'vitest';
+import KubeYamlEditor from '/@/lib/monaco-editor/KubeYamlEditor.svelte';
+import type { QuadletInfo } from '/@shared/src/models/quadlet-info';
+import { QuadletType } from '/@shared/src/utils/quadlet-type';
+import type { ProviderContainerConnectionIdentifierInfo } from '/@shared/src/models/provider-container-connection-identifier-info';
+import { quadletAPI } from '/@/api/client';
+import MonacoEditor from '/@/lib/monaco-editor/MonacoEditor.svelte';
+
+// mock monaco editor
+vi.mock('/@/lib/monaco-editor/MonacoEditor.svelte');
+// mock clients
+vi.mock('/@/api/client', () => ({
+  quadletAPI: {
+    getKubeYAML: vi.fn(),
+  },
+}));
+
+const MOCK_YAML = `
+foo=bar
+`;
+
+beforeEach(() => {
+  vi.resetAllMocks();
+
+  vi.mocked(quadletAPI.getKubeYAML).mockResolvedValue(MOCK_YAML);
+});
+
+const PODMAN_MACHINE_DEFAULT: ProviderContainerConnectionIdentifierInfo = {
+  name: 'podman-machine-default',
+  providerId: 'podman',
+};
+
+const KUBE_QUADLET: QuadletInfo & { type: QuadletType.KUBE } = {
+  type: QuadletType.KUBE,
+  id: `foo.bar`,
+  path: `/mnt/foo/bar.kube`,
+  content: 'dummy-content',
+  state: 'active',
+  connection: PODMAN_MACHINE_DEFAULT,
+};
+
+test('ensure reload button is visible', async () => {
+  const { getByTitle } = render(KubeYamlEditor, {
+    quadlet: KUBE_QUADLET,
+    loading: false,
+  });
+
+  const reloadBtn = getByTitle('Reload file');
+  expect(reloadBtn).toBeInTheDocument();
+  // onmount pull the yaml so need to wait for completion
+  await vi.waitFor(() => {
+    expect(reloadBtn).toBeEnabled();
+  });
+});
+
+test('ensure reload button is disabled when loading true', async () => {
+  const { getByTitle } = render(KubeYamlEditor, {
+    quadlet: KUBE_QUADLET,
+    loading: true,
+  });
+
+  const reloadBtn = getByTitle('Reload file');
+  expect(reloadBtn).toBeInTheDocument();
+  expect(reloadBtn).toBeDisabled();
+});
+
+test('expect reload button to call quadletAPI#getKubeYAML', async () => {
+  const { getByTitle } = render(KubeYamlEditor, {
+    quadlet: KUBE_QUADLET,
+    loading: false,
+  });
+
+  const reloadBtn = getByTitle('Reload file');
+  vi.mocked(quadletAPI.getKubeYAML).mockReset();
+  await fireEvent.click(reloadBtn);
+
+  await vi.waitFor(() => {
+    expect(quadletAPI.getKubeYAML).toHaveBeenCalledOnce();
+  });
+});
+
+test('expect result from quadletAPI#getKubeYAML to be displayed in monaco editor', async () => {
+  render(KubeYamlEditor, {
+    quadlet: KUBE_QUADLET,
+    loading: false,
+  });
+
+  await vi.waitFor(() => {
+    expect(quadletAPI.getKubeYAML).toHaveBeenCalled();
+  });
+
+  await vi.waitFor(() => {
+    expect(MonacoEditor).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        content: MOCK_YAML,
+      }),
+    );
+  });
+});
+
+test('expect error from quadletAPI#getKubeYAML to be displayed', async () => {
+  vi.mocked(quadletAPI.getKubeYAML).mockRejectedValue(new Error('Dummy foo error'));
+
+  const { getByRole } = render(KubeYamlEditor, {
+    quadlet: KUBE_QUADLET,
+    loading: false,
+  });
+
+  await vi.waitFor(() => {
+    expect(quadletAPI.getKubeYAML).toHaveBeenCalled();
+  });
+
+  await vi.waitFor(() => {
+    const alert = getByRole('alert');
+    expect(alert).toHaveTextContent('Something went wrong: Error: Dummy foo error');
+  });
+});

--- a/packages/frontend/src/lib/monaco-editor/KubeYamlEditor.svelte
+++ b/packages/frontend/src/lib/monaco-editor/KubeYamlEditor.svelte
@@ -1,0 +1,54 @@
+<script lang="ts">
+import MonacoEditor from '/@/lib/monaco-editor/MonacoEditor.svelte';
+import { quadletAPI } from '/@/api/client';
+import { onMount } from 'svelte';
+import type { QuadletInfo } from '/@shared/src/models/quadlet-info';
+import type { QuadletType } from '/@shared/src/utils/quadlet-type';
+import { ErrorMessage, Button } from '@podman-desktop/ui-svelte';
+import { faRotateRight } from '@fortawesome/free-solid-svg-icons/faRotateRight';
+
+interface Props {
+  quadlet: QuadletInfo & { type: QuadletType.KUBE },
+  loading: boolean,
+}
+
+let { quadlet, loading = $bindable() }: Props = $props();
+
+let content: string | undefined = $state(undefined);
+let error: string | undefined = $state(undefined);
+
+async function pull(): Promise<void> {
+  loading = true;
+  try {
+    content = await quadletAPI.getKubeYAML(quadlet.connection, quadlet.id);
+    error = undefined;
+  } catch (err: unknown) {
+    console.error(err);
+    error = `Something went wrong: ${String(err)}`;
+  } finally {
+    loading = false;
+  }
+}
+
+onMount(() => {
+  pull().catch(console.error);
+});
+</script>
+
+<div class="flex py-2 h-[40px]">
+    <span
+      class="block w-auto text-sm font-medium whitespace-nowrap leading-6 text-[var(--pd-content-text)] pl-2 pr-2">
+      <Button icon={faRotateRight} padding="px-2" disabled={loading} title="reload file" on:click={pull}>Reload</Button>
+    </span>
+</div>
+{#if error}
+  <ErrorMessage error={error} />
+{/if}
+{#if !loading && content && !error}
+  <MonacoEditor
+    class="h-full"
+    readOnly={true}
+    bind:content={content}
+    language="yaml" />
+{/if}
+

--- a/packages/frontend/src/lib/monaco-editor/KubeYamlEditor.svelte
+++ b/packages/frontend/src/lib/monaco-editor/KubeYamlEditor.svelte
@@ -37,7 +37,7 @@ onMount(() => {
 
 <div class="flex py-2 h-[40px]">
   <span class="block w-auto text-sm font-medium whitespace-nowrap leading-6 text-[var(--pd-content-text)] pl-2 pr-2">
-    <Button icon={faRotateRight} padding="px-2" disabled={loading} title="reload file" on:click={pull}>Reload</Button>
+    <Button icon={faRotateRight} padding="px-2" disabled={loading} title="Reload file" on:click={pull}>Reload</Button>
   </span>
 </div>
 {#if error}

--- a/packages/frontend/src/lib/monaco-editor/KubeYamlEditor.svelte
+++ b/packages/frontend/src/lib/monaco-editor/KubeYamlEditor.svelte
@@ -8,8 +8,8 @@ import { ErrorMessage, Button } from '@podman-desktop/ui-svelte';
 import { faRotateRight } from '@fortawesome/free-solid-svg-icons/faRotateRight';
 
 interface Props {
-  quadlet: QuadletInfo & { type: QuadletType.KUBE },
-  loading: boolean,
+  quadlet: QuadletInfo & { type: QuadletType.KUBE };
+  loading: boolean;
 }
 
 let { quadlet, loading = $bindable() }: Props = $props();
@@ -36,19 +36,13 @@ onMount(() => {
 </script>
 
 <div class="flex py-2 h-[40px]">
-    <span
-      class="block w-auto text-sm font-medium whitespace-nowrap leading-6 text-[var(--pd-content-text)] pl-2 pr-2">
-      <Button icon={faRotateRight} padding="px-2" disabled={loading} title="reload file" on:click={pull}>Reload</Button>
-    </span>
+  <span class="block w-auto text-sm font-medium whitespace-nowrap leading-6 text-[var(--pd-content-text)] pl-2 pr-2">
+    <Button icon={faRotateRight} padding="px-2" disabled={loading} title="reload file" on:click={pull}>Reload</Button>
+  </span>
 </div>
 {#if error}
   <ErrorMessage error={error} />
 {/if}
 {#if !loading && content && !error}
-  <MonacoEditor
-    class="h-full"
-    readOnly={true}
-    bind:content={content}
-    language="yaml" />
+  <MonacoEditor class="h-full" readOnly={true} bind:content={content} language="yaml" />
 {/if}
-

--- a/packages/frontend/src/lib/table/QuadletActions.spec.ts
+++ b/packages/frontend/src/lib/table/QuadletActions.spec.ts
@@ -19,11 +19,12 @@
 import '@testing-library/jest-dom/vitest';
 
 import { fireEvent, render } from '@testing-library/svelte';
-import { expect, test, vi, beforeEach } from 'vitest';
+import { beforeEach, expect, test, vi } from 'vitest';
 import QuadletActions from '/@/lib/table/QuadletActions.svelte';
 import type { QuadletInfo } from '/@shared/src/models/quadlet-info';
 import type { ProviderContainerConnectionIdentifierInfo } from '/@shared/src/models/provider-container-connection-identifier-info';
 import { dialogAPI, quadletAPI } from '/@/api/client';
+import { QuadletType } from '/@shared/src/utils/quadlet-type';
 
 vi.mock('/@/api/client', () => ({
   dialogAPI: {
@@ -49,6 +50,7 @@ const QUADLET_MOCK: QuadletInfo = {
   state: 'active',
   path: `bar/foo.container`,
   connection: PROVIDER_MOCK,
+  type: QuadletType.CONTAINER,
 };
 
 test('expect active quadlet to have stop enabled', async () => {

--- a/packages/frontend/src/pages/QuadletDetails.spec.ts
+++ b/packages/frontend/src/pages/QuadletDetails.spec.ts
@@ -1,0 +1,109 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render } from '@testing-library/svelte';
+import * as quadletStore from '/@store/quadlets';
+import { beforeEach, expect, test, vi } from 'vitest';
+import type { QuadletInfo } from '/@shared/src/models/quadlet-info';
+import { QuadletType } from '/@shared/src/utils/quadlet-type';
+import { readable } from 'svelte/store';
+import * as connectionStore from '/@store/connections';
+import type { ProviderContainerConnectionDetailedInfo } from '/@shared/src/models/provider-container-connection-detailed-info';
+import QuadletDetails from '/@/pages/QuadletDetails.svelte';
+
+// mock clients
+vi.mock('/@/api/client', () => ({
+  providerAPI: {},
+  quadletAPI: {},
+}));
+// mock stores
+vi.mock('/@store/connections');
+vi.mock('/@store/quadlets');
+// mock component
+vi.mock('/@/lib/monaco-editor/MonacoEditor.svelte');
+
+// ui object
+const WSL_PROVIDER_DETAILED_INFO: ProviderContainerConnectionDetailedInfo = {
+  providerId: 'podman',
+  name: 'podman-machine',
+  vmType: 'WSL',
+  status: 'started',
+};
+
+const CONTAINER_QUADLET_MOCK: QuadletInfo = {
+  connection: WSL_PROVIDER_DETAILED_INFO,
+  id: `foo.container`,
+  content: 'dummy-content',
+  state: 'active',
+  path: `bar/foo.container`,
+  type: QuadletType.CONTAINER,
+};
+
+const IMAGE_QUADLET_MOCK: QuadletInfo = {
+  // either WSL either QEMU
+  connection: WSL_PROVIDER_DETAILED_INFO,
+  id: `foo.image`,
+  content: 'dummy-content',
+  state: 'active',
+  path: `bar/foo.image`,
+  type: QuadletType.IMAGE,
+};
+
+const KUBE_QUADLET_MOCK: QuadletInfo = {
+  // either WSL either QEMU
+  connection: WSL_PROVIDER_DETAILED_INFO,
+  id: `foo.kube`,
+  content: 'dummy-content',
+  state: 'active',
+  path: `bar/foo.kube`,
+  type: QuadletType.KUBE,
+};
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.mocked(quadletStore).quadletsInfo = readable([CONTAINER_QUADLET_MOCK, IMAGE_QUADLET_MOCK, KUBE_QUADLET_MOCK]);
+  vi.mocked(connectionStore).providerConnectionsInfo = readable([WSL_PROVIDER_DETAILED_INFO]);
+});
+
+test('container quadlet should have generated and source tab', async () => {
+  const { getByText, queryByText } = render(QuadletDetails, {
+    connection: WSL_PROVIDER_DETAILED_INFO.name,
+    providerId: WSL_PROVIDER_DETAILED_INFO.providerId,
+    id: CONTAINER_QUADLET_MOCK.id,
+  });
+
+  const generateTab = getByText('Generated');
+  expect(generateTab).toBeInTheDocument();
+  const sourceTab = getByText('Source');
+  expect(sourceTab).toBeInTheDocument();
+  const kubeTab = queryByText('kube yaml');
+  expect(kubeTab).toBeNull();
+});
+
+test('kube quadlet should have kube yaml tab', async () => {
+  const { getByText } = render(QuadletDetails, {
+    connection: WSL_PROVIDER_DETAILED_INFO.name,
+    providerId: WSL_PROVIDER_DETAILED_INFO.providerId,
+    id: KUBE_QUADLET_MOCK.id,
+  });
+
+  const kubeTab = getByText('kube yaml');
+  expect(kubeTab).toBeInTheDocument();
+});

--- a/packages/frontend/src/pages/QuadletsList.spec.ts
+++ b/packages/frontend/src/pages/QuadletsList.spec.ts
@@ -21,7 +21,7 @@ import '@testing-library/jest-dom/vitest';
 import { fireEvent, render } from '@testing-library/svelte';
 
 import * as connectionStore from '/@store/connections';
-import { expect, test, vi, beforeEach } from 'vitest';
+import { beforeEach, expect, test, vi } from 'vitest';
 import QuadletsList from '/@/pages/QuadletsList.svelte';
 import type { ProviderContainerConnectionDetailedInfo } from '/@shared/src/models/provider-container-connection-detailed-info';
 import { readable } from 'svelte/store';
@@ -29,6 +29,7 @@ import * as quadletStore from '/@store/quadlets';
 import type { QuadletInfo } from '/@shared/src/models/quadlet-info';
 import { dialogAPI, quadletAPI } from '/@/api/client';
 import { router } from 'tinro';
+import { QuadletType } from '/@shared/src/utils/quadlet-type';
 
 // ui object
 const WSL_PROVIDER_DETAILED_INFO: ProviderContainerConnectionDetailedInfo = {
@@ -70,6 +71,7 @@ const QUADLETS_MOCK: QuadletInfo[] = Array.from({ length: 10 }, (_, index) => ({
   content: 'dummy-content',
   state: 'active',
   path: `bar/foo-${index}.container`,
+  type: QuadletType.CONTAINER,
 }));
 
 beforeEach(() => {

--- a/packages/frontend/src/utils/quadlet.spec.ts
+++ b/packages/frontend/src/utils/quadlet.spec.ts
@@ -1,0 +1,56 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { test, expect } from 'vitest';
+import { QuadletType } from '/@shared/src/utils/quadlet-type';
+import { isKubeQuadlet } from '/@/utils/quadlet';
+import type { ProviderContainerConnectionIdentifierInfo } from '/@shared/src/models/provider-container-connection-identifier-info';
+
+const PODMAN_MACHINE_DEFAULT: ProviderContainerConnectionIdentifierInfo = {
+  name: 'podman-machine-default',
+  providerId: 'podman',
+};
+
+test.each(Object.values(QuadletType).filter(type => type !== QuadletType.KUBE))(
+  'expect %s not to be recognised as kube',
+  type => {
+    expect(
+      isKubeQuadlet({
+        type: type,
+        id: `foo.bar`,
+        path: `/mnt/foo/bar.${type.toLowerCase()}`,
+        content: 'dummy-content',
+        state: 'active',
+        connection: PODMAN_MACHINE_DEFAULT,
+      }),
+    ).toBeFalsy();
+  },
+);
+
+test(`expect ${QuadletType.KUBE} to be recognised`, () => {
+  expect(
+    isKubeQuadlet({
+      type: QuadletType.KUBE,
+      id: `foo.bar`,
+      path: `/mnt/foo/bar.kube`,
+      content: 'dummy-content',
+      state: 'active',
+      connection: PODMAN_MACHINE_DEFAULT,
+    }),
+  ).toBeTruthy();
+});

--- a/packages/frontend/src/utils/quadlet.ts
+++ b/packages/frontend/src/utils/quadlet.ts
@@ -1,0 +1,25 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+
+import type { QuadletInfo } from '/@shared/src/models/quadlet-info';
+import { QuadletType } from '/@shared/src/utils/quadlet-type';
+
+export function isKubeQuadlet(quadlet: QuadletInfo): quadlet is QuadletInfo & { type: QuadletType.KUBE } {
+  return quadlet.type === QuadletType.KUBE;
+}

--- a/packages/frontend/src/utils/quadlet.ts
+++ b/packages/frontend/src/utils/quadlet.ts
@@ -16,7 +16,6 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-
 import type { QuadletInfo } from '/@shared/src/models/quadlet-info';
 import { QuadletType } from '/@shared/src/utils/quadlet-type';
 

--- a/packages/shared/src/apis/quadlet-api.ts
+++ b/packages/shared/src/apis/quadlet-api.ts
@@ -41,4 +41,6 @@ export abstract class QuadletApi {
   }): Promise<void>;
 
   abstract getSynchronisationInfo(): Promise<SynchronisationInfo[]>;
+
+  abstract getKubeYAML(connection: ProviderContainerConnectionIdentifierInfo, id: string): Promise<string>;
 }

--- a/packages/shared/src/messages/constants.ts
+++ b/packages/shared/src/messages/constants.ts
@@ -8,4 +8,5 @@ export const noTimeoutChannels: string[] = [
   getChannel(QuadletApi, 'saveIntoMachine'),
   getChannel(DialogApi, 'showWarningMessage'),
   getChannel(QuadletApi, 'start'),
+  getChannel(QuadletApi, 'updateIntoMachine'),
 ];

--- a/packages/shared/src/models/quadlet-info.ts
+++ b/packages/shared/src/models/quadlet-info.ts
@@ -2,6 +2,7 @@
  * @author axel7083
  */
 import type { ProviderContainerConnectionIdentifierInfo } from './provider-container-connection-identifier-info';
+import type { QuadletType } from '../utils/quadlet-type';
 
 export interface QuadletInfo {
   id: string;
@@ -13,4 +14,6 @@ export interface QuadletInfo {
   content: string;
   // the connection linked
   connection: ProviderContainerConnectionIdentifierInfo;
+  // type of quadlet
+  type: QuadletType;
 }


### PR DESCRIPTION
Fixes https://github.com/podman-desktop/extension-podman-quadlet/issues/40

![image](https://github.com/user-attachments/assets/09714e62-dd6f-4f94-ab9d-8b713c68931a)

## testing

Available at `quay.io/rh-ee-astefani/podman-quadlet-prerelease:0.8.0`
