### PR TITLE
fix: adding QuadletApi#start to noTimeoutChannels

### DIFF
--- a/packages/shared/src/messages/constants.ts
+++ b/packages/shared/src/messages/constants.ts
@@ -7,4 +7,5 @@ export const noTimeoutChannels: string[] = [
   getChannel(PodletApi, 'install'),
   getChannel(QuadletApi, 'saveIntoMachine'),
   getChannel(DialogApi, 'showWarningMessage'),
+  getChannel(QuadletApi, 'start'),
 ];


### PR DESCRIPTION
Fixes https://github.com/podman-desktop/extension-podman-quadlet/issues/249