### PR TITLE
fix: adding missing quadlet type build

### DIFF
--- a/packages/shared/src/utils/quadlet-type.ts
+++ b/packages/shared/src/utils/quadlet-type.ts
@@ -1,5 +1,5 @@
-// we cannot generate quadlet type for kube
-export type QuadletTypeGenerate = Exclude<QuadletType, QuadletType.KUBE>;
+// we cannot generate quadlet type for kube or build
+export type QuadletTypeGenerate = Exclude<QuadletType, QuadletType.KUBE | QuadletType.BUILD>;
 
 export enum QuadletType {
   CONTAINER = 'Container',
@@ -8,4 +8,5 @@ export enum QuadletType {
   VOLUME = 'Volume',
   NETWORK = 'Network',
   KUBE = 'Kube',
+  BUILD = 'Build',
 }


### PR DESCRIPTION
When working on https://github.com/podman-desktop/extension-podman-quadlet/issues/40 noticed that the `build` quadlet type was missing lead to errors when parsing them (not recognised).

