### PR TITLE
feat(ui): disable buttons when no connections running

### DIFF
--- a/packages/frontend/src/lib/empty-screen/EmptyQuadletList.spec.ts
+++ b/packages/frontend/src/lib/empty-screen/EmptyQuadletList.spec.ts
@@ -117,3 +117,24 @@ test('refresh button should call provider callback', async () => {
     expect(refreshMock).toHaveBeenCalledOnce();
   });
 });
+
+test('refresh button should be disabled if disable props is true', async () => {
+  vi.mocked(connectionStore).providerConnectionsInfo = readable([WSL_STOPPED_PROVIDER_DETAILED_INFO]);
+  vi.mocked(synchronisationStore).synchronisation = readable([]);
+
+  const { getByRole } = render(EmptyQuadletList, {
+    refreshQuadlets: vi.fn(),
+    disabled: true,
+  });
+
+  const button = await vi.waitFor(() => {
+    const element = getByRole('button', { name: 'Refresh' });
+    expect(element).toBeDefined();
+    return element;
+  });
+
+  await vi.waitFor(() => {
+    expect(button).toBeDisabled();
+  });
+});
+

--- a/packages/frontend/src/lib/empty-screen/EmptyQuadletList.spec.ts
+++ b/packages/frontend/src/lib/empty-screen/EmptyQuadletList.spec.ts
@@ -137,4 +137,3 @@ test('refresh button should be disabled if disable props is true', async () => {
     expect(button).toBeDisabled();
   });
 });
-

--- a/packages/frontend/src/lib/empty-screen/EmptyQuadletList.svelte
+++ b/packages/frontend/src/lib/empty-screen/EmptyQuadletList.svelte
@@ -8,11 +8,12 @@ import { synchronisation } from '/@store/synchronisation';
 interface Props {
   connection?: ProviderContainerConnectionDetailedInfo;
   loading?: boolean;
+  disabled?: boolean;
   // actions
   refreshQuadlets: () => void;
 }
 
-let { connection, loading, refreshQuadlets }: Props = $props();
+let { connection, loading, disabled, refreshQuadlets }: Props = $props();
 
 let runningConnection: number = $derived(
   $providerConnectionsInfo.reduce((accumulator, connection) => {
@@ -59,7 +60,7 @@ let message: string = $derived.by(() => {
       <Button
         icon={faArrowsRotate}
         inProgress={loading}
-        disabled={loading}
+        disabled={disabled}
         title="Refresh Quadlets"
         on:click={refreshQuadlets}>Refresh</Button>
     </div>

--- a/packages/frontend/src/pages/QuadletsList.spec.ts
+++ b/packages/frontend/src/pages/QuadletsList.spec.ts
@@ -131,10 +131,12 @@ test('Refresh Quadlet button should be disabled if only stopped provider are ava
   // mock no quadlets
   vi.mocked(quadletStore).quadletsInfo = readable([]);
   // mock no providers
-  vi.mocked(connectionStore).providerConnectionsInfo = readable([{
-    ...WSL_PROVIDER_DETAILED_INFO,
-    status: 'stopped',
-  }]);
+  vi.mocked(connectionStore).providerConnectionsInfo = readable([
+    {
+      ...WSL_PROVIDER_DETAILED_INFO,
+      status: 'stopped',
+    },
+  ]);
 
   const { getByRole } = render(QuadletsList);
 

--- a/packages/frontend/src/pages/QuadletsList.spec.ts
+++ b/packages/frontend/src/pages/QuadletsList.spec.ts
@@ -61,8 +61,11 @@ vi.mock('/@/api/client', () => ({
 // mock stores
 vi.mock('/@store/connections');
 vi.mock('/@store/quadlets');
+vi.mock('/@store/synchronisation');
 // mock utils
 vi.mock('tinro');
+// mock components
+vi.mock('/@/lib/empty-screen/EmptyQuadletList.svelte');
 
 const QUADLETS_MOCK: QuadletInfo[] = Array.from({ length: 10 }, (_, index) => ({
   // either WSL either QEMU
@@ -102,6 +105,37 @@ test('Generate Quadlet button should redirect to generate form', async () => {
 });
 
 test('Refresh Quadlet button should call ', async () => {
+  const { getByRole } = render(QuadletsList);
+
+  const refreshBtn = getByRole('button', { name: 'Refresh' });
+  await fireEvent.click(refreshBtn);
+
+  expect(quadletAPI.refresh).toHaveBeenCalled();
+});
+
+test('Refresh Quadlet button should be disabled if no provider is available', async () => {
+  // mock no quadlets
+  vi.mocked(quadletStore).quadletsInfo = readable([]);
+  // mock no providers
+  vi.mocked(connectionStore).providerConnectionsInfo = readable([]);
+
+  const { getByRole } = render(QuadletsList);
+
+  const refreshBtn = getByRole('button', { name: 'Refresh' });
+  await fireEvent.click(refreshBtn);
+
+  expect(quadletAPI.refresh).toHaveBeenCalled();
+});
+
+test('Refresh Quadlet button should be disabled if only stopped provider are available', async () => {
+  // mock no quadlets
+  vi.mocked(quadletStore).quadletsInfo = readable([]);
+  // mock no providers
+  vi.mocked(connectionStore).providerConnectionsInfo = readable([{
+    ...WSL_PROVIDER_DETAILED_INFO,
+    status: 'stopped',
+  }]);
+
   const { getByRole } = render(QuadletsList);
 
   const refreshBtn = getByRole('button', { name: 'Refresh' });

--- a/packages/frontend/src/pages/QuadletsList.svelte
+++ b/packages/frontend/src/pages/QuadletsList.svelte
@@ -49,6 +49,11 @@ const columns = [
 const row = new TableRow<QuadletInfo>({ selectable: (_service): boolean => true });
 
 let loading: boolean = $state(false);
+// considered disable if there is no connection running or loading
+let disabled: boolean = $derived(
+  loading || !$providerConnectionsInfo.some(({ status }) => status === 'started'),
+);
+
 async function refreshQuadlets(): Promise<void> {
   loading = true;
   try {
@@ -123,12 +128,12 @@ async function deleteSelected(): Promise<void> {
 
 <NavPage title="Podman Quadlets" searchEnabled={true} bind:searchTerm={searchTerm}>
   <svelte:fragment slot="additional-actions">
-    <Button icon={faCode} disabled={loading} title="Generate Quadlet" on:click={navigateToGenerate}
+    <Button icon={faCode} disabled={disabled} title="Generate Quadlet" on:click={navigateToGenerate}
       >Generate Quadlet</Button>
     <Button
       icon={faArrowsRotate}
       inProgress={loading}
-      disabled={loading}
+      disabled={disabled}
       title="Refresh Quadlets"
       on:click={refreshQuadlets}>Refresh</Button>
   </svelte:fragment>
@@ -161,7 +166,7 @@ async function deleteSelected(): Promise<void> {
         bind:selectedItemsNumber={selectedItemsNumber}
         defaultSortColumn="Environment" />
     {:else}
-      <EmptyQuadletList connection={containerProviderConnection} refreshQuadlets={refreshQuadlets} loading={loading} />
+      <EmptyQuadletList connection={containerProviderConnection} refreshQuadlets={refreshQuadlets} loading={loading} disabled={disabled} />
     {/if}
   </svelte:fragment>
 </NavPage>

--- a/packages/frontend/src/pages/QuadletsList.svelte
+++ b/packages/frontend/src/pages/QuadletsList.svelte
@@ -50,9 +50,7 @@ const row = new TableRow<QuadletInfo>({ selectable: (_service): boolean => true 
 
 let loading: boolean = $state(false);
 // considered disable if there is no connection running or loading
-let disabled: boolean = $derived(
-  loading || !$providerConnectionsInfo.some(({ status }) => status === 'started'),
-);
+let disabled: boolean = $derived(loading || !$providerConnectionsInfo.some(({ status }) => status === 'started'));
 
 async function refreshQuadlets(): Promise<void> {
   loading = true;
@@ -166,7 +164,11 @@ async function deleteSelected(): Promise<void> {
         bind:selectedItemsNumber={selectedItemsNumber}
         defaultSortColumn="Environment" />
     {:else}
-      <EmptyQuadletList connection={containerProviderConnection} refreshQuadlets={refreshQuadlets} loading={loading} disabled={disabled} />
+      <EmptyQuadletList
+        connection={containerProviderConnection}
+        refreshQuadlets={refreshQuadlets}
+        loading={loading}
+        disabled={disabled} />
     {/if}
   </svelte:fragment>
 </NavPage>


### PR DESCRIPTION
## Description

Disable the buttons when no connection are available or when no running connection are found.

![image](https://github.com/user-attachments/assets/08f570d6-9f5e-4298-8dd4-7acdc0ac5349)

## Related issues

Fixes https://github.com/podman-desktop/extension-podman-quadlet/issues/299

