### PR TITLE
refactor: using uuid for quadlet id

### DIFF
--- a/packages/backend/src/models/quadlet.ts
+++ b/packages/backend/src/models/quadlet.ts
@@ -28,7 +28,7 @@ export interface Quadlet {
    */
   state: 'active' | 'inactive' | 'deleting' | 'unknown';
   /**
-   * quadlet can have multiple type (container, image etc.)
+   * quadlet have a type based on their extension (.container, .image etc.)
    */
   type: QuadletType;
 }

--- a/packages/backend/src/models/quadlet.ts
+++ b/packages/backend/src/models/quadlet.ts
@@ -4,11 +4,31 @@
 import type { QuadletType } from '/@shared/src/utils/quadlet-type';
 
 export interface Quadlet {
+  /**
+   * UUID to internally identify the quadlet
+   * @remarks the id is not persisted
+   */
   id: string;
+  /**
+   * systemd service name
+   * @remarks may be undefined if the quadlet is invalid
+   */
+  service?: string;
+  /**
+   * path to the quadlet file
+   * @example "~/.config/containers/systemd/foo.container"
+   */
   path: string;
-  // raw content (generate) of the service file
+  /**
+   * raw content (generate) of the service file
+   */
   content: string;
+  /**
+   * State of the quadlet
+   */
   state: 'active' | 'inactive' | 'deleting' | 'unknown';
-  // type of quadlet
+  /**
+   * quadlet can have multiple type (container, image etc.)
+   */
   type: QuadletType;
 }

--- a/packages/backend/src/utils/parsers/quadlet-unit-parser.spec.ts
+++ b/packages/backend/src/utils/parsers/quadlet-unit-parser.spec.ts
@@ -46,6 +46,7 @@ test('expect path to be properly extracted', async () => {
     expect.objectContaining({
       path: '/home/user/.config/containers/systemd/nginx2.container',
       type: QuadletType.CONTAINER,
+      service: DUMMY_SERVICE_NAME,
     }),
   );
 });
@@ -57,6 +58,7 @@ test('expect content to be identical to input', async () => {
   expect(result).toStrictEqual(
     expect.objectContaining({
       content: CONTAINER_QUADLET_EXAMPLE,
+      service: DUMMY_SERVICE_NAME,
     }),
   );
 });

--- a/packages/backend/src/utils/parsers/quadlet-unit-parser.ts
+++ b/packages/backend/src/utils/parsers/quadlet-unit-parser.ts
@@ -6,6 +6,7 @@ import { Parser } from './iparser';
 import { parse } from 'js-ini';
 import type { Quadlet } from '../../models/quadlet';
 import { QuadletType } from '/@shared/src/utils/quadlet-type';
+import { randomUUID } from 'node:crypto';
 
 interface Unit {
   SourcePath: string;
@@ -27,6 +28,10 @@ export class QuadletUnitParser extends Parser<string, Quadlet> {
     };
   }
 
+  protected generateUUID(): string {
+    return randomUUID();
+  }
+
   override parse(): Quadlet {
     const raw = parse(this.content, {
       comment: ['#', ';'],
@@ -39,7 +44,8 @@ export class QuadletUnitParser extends Parser<string, Quadlet> {
 
     return {
       path: unit.SourcePath,
-      id: this.serviceName,
+      service: this.serviceName,
+      id: this.generateUUID(),
       content: this.content,
       state: 'unknown',
       type: type,

--- a/packages/frontend/src/pages/QuadletDetails.svelte
+++ b/packages/frontend/src/pages/QuadletDetails.svelte
@@ -39,6 +39,8 @@ let quadlet: QuadletInfo | undefined = $derived(
       quadlet.id === id && quadlet.connection.name === connection && quadlet.connection.providerId === providerId,
   ),
 );
+// the title is either the systemd service name or if undefined the last part of the path (E.g. /foo/bar.container => bar.container)
+let title: string = $derived(quadlet?.service ?? quadlet?.path.split('/').pop() ?? 'none');
 
 export function close(): void {
   router.goto('/');
@@ -127,10 +129,10 @@ function onchange(content: string): void {
 
 {#if quadlet}
   <DetailsPage
-    title={quadlet.id}
+    title={title}
     onclose={close}
     breadcrumbLeftPart="Quadlets"
-    breadcrumbRightPart={quadlet.id}
+    breadcrumbRightPart={title}
     breadcrumbTitle="Go back to quadlets page"
     onbreadcrumbClick={close}>
     <svelte:fragment slot="actions">

--- a/packages/frontend/src/pages/QuadletsList.spec.ts
+++ b/packages/frontend/src/pages/QuadletsList.spec.ts
@@ -64,10 +64,11 @@ vi.mock('/@store/quadlets');
 // mock utils
 vi.mock('tinro');
 
-const QUADLETS_MOCK: QuadletInfo[] = Array.from({ length: 10 }, (_, index) => ({
+const QUADLETS_MOCK: Array<QuadletInfo & { service: string }> = Array.from({ length: 10 }, (_, index) => ({
   // either WSL either QEMU
   connection: index % 2 === 0 ? WSL_PROVIDER_DETAILED_INFO : QEMU_PROVIDER_DETAILED_INFO,
-  id: `foo-${index}.container`,
+  id: `random-${index}`,
+  service: `foo-${index}.service`,
   content: 'dummy-content',
   state: 'active',
   path: `bar/foo-${index}.container`,
@@ -87,7 +88,7 @@ test('all quadlets should be visible', async () => {
   const { getByText } = render(QuadletsList);
 
   for (const quadlet of QUADLETS_MOCK) {
-    const div = getByText(quadlet.id);
+    const div = getByText(quadlet.service);
     expect(div).toBeInTheDocument();
   }
 });

--- a/packages/frontend/src/pages/QuadletsList.svelte
+++ b/packages/frontend/src/pages/QuadletsList.svelte
@@ -28,7 +28,7 @@ const columns = [
     renderer: TableSimpleColumn,
     align: 'left',
     width: '200px',
-    renderMapping: (quadletsInfo: QuadletInfo): string => quadletsInfo.id,
+    renderMapping: (quadletsInfo: QuadletInfo): string => quadletsInfo.service ?? 'unknown',
     comparator: (a, b): number => a.id.localeCompare(b.id),
   }),
   new TableColumn<QuadletInfo, ProviderContainerConnectionIdentifierInfo>('Environment', {

--- a/packages/shared/src/models/quadlet-info.ts
+++ b/packages/shared/src/models/quadlet-info.ts
@@ -33,7 +33,7 @@ export interface QuadletInfo {
    */
   connection: ProviderContainerConnectionIdentifierInfo;
   /**
-   * quadlet can have multiple type (container, image etc.)
+   * quadlet have a type based on their extension (.container, .image etc.)
    */
   type: QuadletType;
 }

--- a/packages/shared/src/models/quadlet-info.ts
+++ b/packages/shared/src/models/quadlet-info.ts
@@ -5,15 +5,35 @@ import type { ProviderContainerConnectionIdentifierInfo } from './provider-conta
 import type { QuadletType } from '../utils/quadlet-type';
 
 export interface QuadletInfo {
+  /**
+   * UUID to internally identify the quadlet
+   * @remarks the id is not persisted between reboot
+   */
   id: string;
-  // absolute path in the machine
+  /**
+   * systemd service name
+   * @remarks may be undefined if the quadlet is invalid
+   */
+  service?: string;
+  /**
+   * path to the quadlet file
+   * @example "~/.config/containers/systemd/foo.container"
+   */
   path: string;
-  state: 'active' | 'inactive' | 'deleting' | 'unknown';
-
-  // raw content of the service file
+  /**
+   * raw content (generate) of the service file
+   */
   content: string;
-  // the connection linked
+  /**
+   * State of the quadlet
+   */
+  state: 'active' | 'inactive' | 'deleting' | 'error' | 'unknown';
+  /**
+   * Associate connection to the quadlet
+   */
   connection: ProviderContainerConnectionIdentifierInfo;
-  // type of quadlet
+  /**
+   * quadlet can have multiple type (container, image etc.)
+   */
   type: QuadletType;
 }


### PR DESCRIPTION
## Description

Today the `(Quadlet | QuadletInfo)#id` were the corresponding systemd service name the quadlet executable were assigning to the quadlet. 

This has some limitation: when a quadlet is invalid, there is not corresponding systemd service. However, we may want to still display them in the list, so the users can edit them.

## Changes

- Adding `service?: string` property to `QuadletInfo`
- Making the `id` meaningless (using uuid)
- Using `QuadletInfo#service` for quadlet table and quadlet details title

## Related issue

Fixes https://github.com/podman-desktop/extension-podman-quadlet/issues/305

## Testing

- [x] unit tests has been updated