### PR TITLE
fix: systemd service refresh only quadlet with associated service

### DIFF
--- a/packages/backend/src/services/quadlet-service.spec.ts
+++ b/packages/backend/src/services/quadlet-service.spec.ts
@@ -275,9 +275,11 @@ describe('QuadletService#refreshQuadletsStatuses', () => {
     await quadlet.collectPodmanQuadlet();
 
     // should have been called only with the quadlet with a corresponding service
-    expect(SYSTEMD_SERVICE_MOCK.getActiveStatus).toHaveBeenCalledWith(expect.objectContaining({
-      services: [QUADLET_MOCK.service],
-    }));
+    expect(SYSTEMD_SERVICE_MOCK.getActiveStatus).toHaveBeenCalledWith(
+      expect.objectContaining({
+        services: [QUADLET_MOCK.service],
+      }),
+    );
   });
 
   test('should use result from SystemdService#getActiveStatus', async () => {
@@ -294,8 +296,8 @@ describe('QuadletService#refreshQuadletsStatuses', () => {
 
     const quadlets = quadlet.all();
 
-    const validQuadlet = quadlets.find((quadlet) => quadlet.path === QUADLET_MOCK.path);
-    const serviceLessQuadlet = quadlets.find((quadlet) => quadlet.path === SERVICE_LESS_QUADLET_MOCK.path);
+    const validQuadlet = quadlets.find(quadlet => quadlet.path === QUADLET_MOCK.path);
+    const serviceLessQuadlet = quadlets.find(quadlet => quadlet.path === SERVICE_LESS_QUADLET_MOCK.path);
 
     // should update known service
     expect(validQuadlet?.state).toStrictEqual('inactive');

--- a/packages/backend/src/services/quadlet-service.spec.ts
+++ b/packages/backend/src/services/quadlet-service.spec.ts
@@ -93,9 +93,18 @@ const RUN_RESULT_MOCK: RunResult = {
   stderr: 'dummy-stderr',
 };
 
-const QUADLET_MOCK: Quadlet = {
-  id: 'foo.service',
-  path: 'foo/bar',
+const QUADLET_MOCK: Quadlet & { service: string } = {
+  id: 'foo-id',
+  service: 'foo.service',
+  path: 'foo/valid.container',
+  state: 'unknown',
+  content: 'dummy-content',
+  type: QuadletType.CONTAINER,
+};
+
+const SERVICE_LESS_QUADLET_MOCK: Quadlet = {
+  id: 'service-less-id',
+  path: 'foo/invalid.container',
   state: 'unknown',
   content: 'dummy-content',
   type: QuadletType.CONTAINER,
@@ -116,7 +125,7 @@ beforeEach(() => {
   });
 
   vi.mocked(PODMAN_SERVICE_MOCK.quadletExec).mockResolvedValue(RUN_RESULT_MOCK);
-  vi.mocked(QuadletDryRunParser.prototype.parse).mockResolvedValue([QUADLET_MOCK]);
+  vi.mocked(QuadletDryRunParser.prototype.parse).mockResolvedValue([QUADLET_MOCK, SERVICE_LESS_QUADLET_MOCK]);
   vi.mocked(WEBVIEW_MOCK.postMessage).mockResolvedValue(true);
 
   vi.mocked(WINDOW_MOCK.withProgress).mockImplementation((_options, tasks): Promise<unknown> => {
@@ -146,7 +155,7 @@ describe('QuadletService#collectPodmanQuadlet', () => {
       args: ['-dryrun', '-user'],
     });
 
-    expect(quadlet.all()).toHaveLength(1);
+    expect(quadlet.all()).toHaveLength(2);
   });
 });
 
@@ -261,19 +270,37 @@ describe('QuadletService#saveIntoMachine', () => {
 });
 
 describe('QuadletService#refreshQuadletsStatuses', () => {
+  test('should only provide quadlet with corresponding service', async () => {
+    const quadlet = getQuadletService();
+    await quadlet.collectPodmanQuadlet();
+
+    // should have been called only with the quadlet with a corresponding service
+    expect(SYSTEMD_SERVICE_MOCK.getActiveStatus).toHaveBeenCalledWith(expect.objectContaining({
+      services: [QUADLET_MOCK.service],
+    }));
+  });
+
   test('should use result from SystemdService#getActiveStatus', async () => {
     const quadlet = getQuadletService();
     await quadlet.collectPodmanQuadlet();
 
     expect(quadlet.all()[0].state).toStrictEqual('active');
 
+    // mock status of quadlet inactive
     vi.mocked(SYSTEMD_SERVICE_MOCK.getActiveStatus).mockResolvedValue({
       [QUADLET_MOCK.id]: false,
     });
-
     await quadlet.refreshQuadletsStatuses();
 
-    expect(quadlet.all()[0].state).toStrictEqual('inactive');
+    const quadlets = quadlet.all();
+
+    const validQuadlet = quadlets.find((quadlet) => quadlet.path === QUADLET_MOCK.path);
+    const serviceLessQuadlet = quadlets.find((quadlet) => quadlet.path === SERVICE_LESS_QUADLET_MOCK.path);
+
+    // should update known service
+    expect(validQuadlet?.state).toStrictEqual('inactive');
+    // should not update service
+    expect(serviceLessQuadlet?.state).toStrictEqual('unknown');
   });
 });
 

--- a/packages/backend/src/services/quadlet-service.ts
+++ b/packages/backend/src/services/quadlet-service.ts
@@ -205,7 +205,9 @@ export class QuadletService extends QuadletHelper implements Disposable, AsyncIn
       const statuses = await this.dependencies.systemd.getActiveStatus({
         provider: provider,
         admin: false,
-        services: quadlets.filter((quadlet): quadlet is Quadlet & { service: string } => !!quadlet.service).map(quadlet => quadlet.service),
+        services: quadlets
+          .filter((quadlet): quadlet is Quadlet & { service: string } => !!quadlet.service)
+          .map(quadlet => quadlet.service),
       });
 
       // update each quadlets

--- a/packages/backend/src/services/quadlet-service.ts
+++ b/packages/backend/src/services/quadlet-service.ts
@@ -192,28 +192,27 @@ export class QuadletService extends QuadletHelper implements Disposable, AsyncIn
   }
 
   /**
-   * @remarks only refresh the statuses of ***known** quadlets, do not catch new ones.
+   * @remarks only refresh the statuses of ***known** quadlets with associate service name, do not catch new ones.
    * todo: optimise ? paralele ?
    */
   async refreshQuadletsStatuses(notify = true): Promise<void> {
     for (const [symbol, quadlets] of Array.from(this.#value.entries())) {
-      // retreive the provider from the symbol
+      // retrieve the provider from the symbol
       const providerIdentifier = this.fromSymbol(symbol);
       const provider = this.providers.getProviderContainerConnection(providerIdentifier);
 
-      // get the statuses of the quadlets
+      // get the statuses of the quadlets with a corresponding service
       const statuses = await this.dependencies.systemd.getActiveStatus({
         provider: provider,
         admin: false,
-        services: quadlets.map(quadlet => quadlet.id),
+        services: quadlets.filter((quadlet): quadlet is Quadlet & { service: string } => !!quadlet.service).map(quadlet => quadlet.service),
       });
 
       // update each quadlets
       for (const quadlet of quadlets) {
+        // only update service we have information about
         if (quadlet.id in statuses) {
           quadlet.state = statuses[quadlet.id] ? 'active' : 'inactive';
-        } else {
-          quadlet.state = 'unknown';
         }
       }
 


### PR DESCRIPTION
## Description

Following https://github.com/podman-desktop/extension-podman-quadlet/pull/306 we should only try to get the statuses of quadlet **with an associated** systemd service, moreover only update the statuses of those quadlet.

##  Related issue

Fixes https://github.com/podman-desktop/extension-podman-quadlet/issues/311