### PR TITLE
fix(systemd): using quadlet service for start stop and log operation

### DIFF
--- a/packages/backend/src/apis/quadlet-api-impl.spec.ts
+++ b/packages/backend/src/apis/quadlet-api-impl.spec.ts
@@ -15,25 +15,37 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
-import { expect, test, vi, beforeEach } from 'vitest';
+import { expect, test, vi, beforeEach, describe } from 'vitest';
 import { QuadletApiImpl } from './quadlet-api-impl';
 import type { QuadletService } from '../services/quadlet-service';
 import type { SystemdService } from '../services/systemd-service';
 import type { PodmanService } from '../services/podman-service';
 import type { ProviderService } from '../services/provider-service';
 import type { LoggerService } from '../services/logger-service';
-import type { ProviderContainerConnection } from '@podman-desktop/api';
+import type { ProviderContainerConnection, RunResult } from '@podman-desktop/api';
 import type { ProviderContainerConnectionIdentifierInfo } from '/@shared/src/models/provider-container-connection-identifier-info';
+import type { Quadlet } from '../models/quadlet';
+import { QuadletType } from '/@shared/src/utils/quadlet-type';
+import type { LoggerImpl } from '../utils/logger-impl';
 
 const QUADLET_SERVICE: QuadletService = {
   getKubeYAML: vi.fn(),
+  getQuadlet: vi.fn(),
+  refreshQuadletsStatuses: vi.fn(),
 } as unknown as QuadletService;
-const SYSTEMD_SERVICE: SystemdService = {} as unknown as SystemdService;
-const PODMAN_SERVICE: PodmanService = {} as unknown as PodmanService;
+const SYSTEMD_SERVICE: SystemdService = {
+  start: vi.fn(),
+  stop: vi.fn(),
+} as unknown as SystemdService;
+const PODMAN_SERVICE: PodmanService = {
+  journalctlExec: vi.fn(),
+} as unknown as PodmanService;
 const PROVIDER_SERVICE: ProviderService = {
   getProviderContainerConnection: vi.fn(),
 } as unknown as ProviderService;
-const LOGGER_SERVICE: LoggerService = {} as unknown as LoggerService;
+const LOGGER_SERVICE: LoggerService = {
+  createLogger: vi.fn(),
+} as unknown as LoggerService;
 
 const WSL_PROVIDER_CONNECTION_MOCK: ProviderContainerConnection = {
   connection: {
@@ -49,10 +61,21 @@ const WSL_PROVIDER_IDENTIFIER: ProviderContainerConnectionIdentifierInfo = {
   providerId: WSL_PROVIDER_CONNECTION_MOCK.providerId,
 };
 
+const QUADLET_MOCK: Quadlet & { service: string } = {
+  id: 'foo-id',
+  service: 'foo.service',
+  path: 'foo/bar.container',
+  state: 'unknown',
+  content: 'dummy-content',
+  type: QuadletType.CONTAINER,
+};
+
 beforeEach(() => {
   vi.resetAllMocks();
 
   vi.mocked(PROVIDER_SERVICE.getProviderContainerConnection).mockReturnValue(WSL_PROVIDER_CONNECTION_MOCK);
+  vi.mocked(QUADLET_SERVICE.getQuadlet).mockReturnValue(QUADLET_MOCK);
+  vi.mocked(QUADLET_SERVICE.refreshQuadletsStatuses).mockResolvedValue(undefined);
 });
 
 function getQuadletApiImpl(): QuadletApiImpl {
@@ -73,4 +96,79 @@ test('QuadletApiImpl#getKubeYAML should propagate result from QuadletService#get
   const result = await api.getKubeYAML(WSL_PROVIDER_IDENTIFIER, 'dummy-quadlet-id');
   expect(result).toStrictEqual('dummy-yaml-content');
   expect(PROVIDER_SERVICE.getProviderContainerConnection).toHaveBeenCalledWith(WSL_PROVIDER_IDENTIFIER);
+});
+
+describe.each(['start', 'stop'] as Array<'start' | 'stop'>)('QuadletApiImpl#%s', func => {
+  test('should ensure quadlet exists', async () => {
+    const api = getQuadletApiImpl();
+
+    await api[func](WSL_PROVIDER_IDENTIFIER, QUADLET_MOCK.id);
+    expect(QUADLET_SERVICE.getQuadlet).toHaveBeenCalledWith(QUADLET_MOCK.id);
+  });
+
+  test('should propagate error if quadlet does not have associated service', async () => {
+    vi.mocked(QUADLET_SERVICE.getQuadlet).mockResolvedValue({
+      ...QUADLET_MOCK,
+      service: undefined,
+    });
+
+    const api = getQuadletApiImpl();
+
+    await expect(() => {
+      return api[func](WSL_PROVIDER_IDENTIFIER, QUADLET_MOCK.id);
+    }).rejects.toThrowError(
+      `cannot ${func} quadlet: quadlet with id ${QUADLET_MOCK.id} does not have an associated systemd service`,
+    );
+  });
+
+  test('should call systemd#start with appropriate arguments', async () => {
+    const api = getQuadletApiImpl();
+
+    await api[func](WSL_PROVIDER_IDENTIFIER, QUADLET_MOCK.id);
+
+    expect(SYSTEMD_SERVICE[func]).toHaveBeenCalledWith({
+      provider: WSL_PROVIDER_CONNECTION_MOCK,
+      service: QUADLET_MOCK.service,
+      admin: false,
+    });
+  });
+});
+
+describe('QuadletApiImpl#createQuadletLogger', () => {
+  const LOGGER_MOCK: LoggerImpl = {
+    id: 'dummy-logger-id',
+    token: 'cancellation-token',
+  } as unknown as LoggerImpl;
+
+  beforeEach(() => {
+    vi.mocked(LOGGER_SERVICE.createLogger).mockReturnValue(LOGGER_MOCK);
+    vi.mocked(PODMAN_SERVICE.journalctlExec).mockResolvedValue({} as RunResult);
+  });
+
+  test('should return logger created throw LoggerService#createLogger', async () => {
+    const api = getQuadletApiImpl();
+
+    const loggerId = await api.createQuadletLogger({
+      connection: WSL_PROVIDER_IDENTIFIER,
+      quadletId: QUADLET_MOCK.id,
+    });
+    expect(loggerId).toStrictEqual(LOGGER_MOCK.id);
+  });
+
+  test('should call podman#journalctlExec with appropriate arguments', async () => {
+    const api = getQuadletApiImpl();
+
+    await api.createQuadletLogger({
+      connection: WSL_PROVIDER_IDENTIFIER,
+      quadletId: QUADLET_MOCK.id,
+    });
+
+    expect(PODMAN_SERVICE.journalctlExec).toHaveBeenCalledWith({
+      connection: WSL_PROVIDER_CONNECTION_MOCK,
+      args: ['--user', '--follow', `--unit=${QUADLET_MOCK.service}`, '--output=cat'],
+      logger: LOGGER_MOCK,
+      token: expect.anything(),
+      env: expect.anything(),
+    });
+  });
 });

--- a/packages/backend/src/services/quadlet-service.spec.ts
+++ b/packages/backend/src/services/quadlet-service.spec.ts
@@ -444,3 +444,24 @@ describe('QuadletService#getSynchronisationInfo', () => {
     expect(sync).toHaveLength(1);
   });
 });
+
+describe('QuadletService#getQuadlet', () => {
+  test('should throw an error for unknown id', async () => {
+    const quadlet = getQuadletService();
+    expect(() => {
+      quadlet.getQuadlet('invalid-id');
+    }).toThrowError('cannot found quadlet with id invalid-id');
+  });
+
+  test('should contain provider synchronisation', async () => {
+    const quadlet = getQuadletService();
+    await quadlet.collectPodmanQuadlet();
+
+    const quadlets = quadlet.all();
+    for (const item of quadlets) {
+      const result = quadlet.getQuadlet(item.id);
+      expect(result).toBeDefined();
+      expect(result.id).toStrictEqual(item.id);
+    }
+  });
+});

--- a/packages/backend/src/services/quadlet-service.ts
+++ b/packages/backend/src/services/quadlet-service.ts
@@ -31,6 +31,19 @@ export class QuadletService extends QuadletHelper implements Disposable, AsyncIn
   }
 
   /**
+   * Get a {@link Quadlet} object given an id.
+   * @remarks throw an error if the quadlet does not exist
+   * @param quadletId
+   */
+  public getQuadlet(quadletId: string): Quadlet {
+    for (const quadlets of this.#value.values()) {
+      const result = quadlets.find(quadlet => quadlet.id === quadletId);
+      if (result) return result;
+    }
+    throw new Error(`cannot found quadlet with id ${quadletId}`);
+  }
+
+  /**
    * Transform the Map<ProviderContainerConnection, Quadlet[]> to a flat {@link QuadletInfo} array
    */
   override all(): QuadletInfo[] {

--- a/packages/shared/src/apis/quadlet-api.ts
+++ b/packages/shared/src/apis/quadlet-api.ts
@@ -11,13 +11,27 @@ export abstract class QuadletApi {
 
   abstract all(): Promise<QuadletInfo[]>;
   abstract refresh(): Promise<void>;
+
+  /**
+   * Given a connection and a quadlet id, start the corresponding systemd service
+   * @remarks throw an error if the quadlet does not have an associated systemd service
+   * @param connection the connection where the quadlet is hosted
+   * @param id the id of the quadlet
+   */
   abstract start(connection: ProviderContainerConnectionIdentifierInfo, id: string): Promise<boolean>;
+  /**
+   * Given a connection and a quadlet id, stop the corresponding systemd service
+   * @remarks throw an error if the quadlet does not have an associated systemd service
+   * @param connection the connection where the quadlet is hosted
+   * @param id the id of the quadlet
+   */
   abstract stop(connection: ProviderContainerConnectionIdentifierInfo, id: string): Promise<boolean>;
   abstract remove(connection: ProviderContainerConnectionIdentifierInfo, ...ids: string[]): Promise<void>;
   abstract read(connection: ProviderContainerConnectionIdentifierInfo, id: string): Promise<string>;
 
   /**
    * This method will use journalctl to create a logger
+   * @remarks throw an error if the quadlet does not have an associated systemd service
    * @param options
    */
   abstract createQuadletLogger(options: {


### PR DESCRIPTION
## Description

The `quadlet-api-impl` were still using the `quadlet#id` to start / stop / log systemd service. This PR change this behaviour, to use the `quadlet#service`.

## Related issue

Fixes https://github.com/podman-desktop/extension-podman-quadlet/issues/313

## Testing

- [x] unit tests has been added

**Manually**

1. Open the quadlet details page
2. go to logs tab
3. click on start
4. assert logs are showing up

