### PR TITLE
test(e2e): full create, start, stop, remove scenario

### DIFF
--- a/tests/playwright/src/model/quadlet-details-page.ts
+++ b/tests/playwright/src/model/quadlet-details-page.ts
@@ -1,0 +1,31 @@
+import { QuadletBasePage } from './quadlet-base-page';
+import type { Locator, Page } from '@playwright/test';
+import { expect as playExpect } from '@playwright/test';
+
+export class QuadletDetailsPage extends QuadletBasePage {
+  readonly actions: Locator;
+  readonly start: Locator;
+  readonly stop: Locator;
+  readonly remove: Locator;
+
+  constructor(page: Page, webview: Page, service: string) {
+    super(page, webview, service);
+
+    this.actions = this.webview.getByRole('group', { name: 'Control Actions' });
+
+    // actions button
+    this.start = this.actions.getByRole('button', { name: 'Start quadlet' });
+    this.stop = this.actions.getByRole('button', { name: 'Stop quadlet' });
+    this.remove = this.actions.getByRole('button', { name: 'Remove quadlet' });
+  }
+
+  async isActive(): Promise<boolean> {
+    const div = this.webview.getByRole('status');
+    const title = await div.getAttribute('title');
+    return title === 'RUNNING';
+  }
+
+  waitForLoad(): Promise<void> {
+    return playExpect(this.heading).toBeVisible();
+  }
+}

--- a/tests/playwright/src/model/quadlet-list-page.ts
+++ b/tests/playwright/src/model/quadlet-list-page.ts
@@ -1,15 +1,24 @@
 import type { Locator, Page } from '@playwright/test';
-import { expect as playExpect } from '@playwright/test';
+import test, { expect as playExpect } from '@playwright/test';
 import { QuadletBasePage } from './quadlet-base-page';
 import { QuadletGeneratePage } from './quadlet-generate-page';
 
 export class QuadletListPage extends QuadletBasePage {
   readonly generateButton: Locator;
+  readonly table: Locator;
+  readonly rows: Locator;
 
   constructor(page: Page, webview: Page) {
     super(page, webview, 'Podman Quadlets');
 
     this.generateButton = this.webview.getByRole('button', { name: 'Generate Quadlet' });
+    this.table = this.webview.getByRole('table', { name: 'quadlets' });
+    this.rows = this.table.getByRole('row');
+  }
+
+  async pageIsEmpty(): Promise<boolean> {
+    const emptyHeading = this.webview.getByRole('heading', { name: 'No Quadlets', exact: true });
+    return (await emptyHeading.count()) > 0;
   }
 
   async waitForLoad(): Promise<void> {
@@ -20,5 +29,19 @@ export class QuadletListPage extends QuadletBasePage {
     await playExpect(this.generateButton).toBeEnabled();
     await this.generateButton.click();
     return new QuadletGeneratePage(this.page, this.webview);
+  }
+
+  async getQuadletRow(service: string): Promise<Locator> {
+    return test.step(`Get service ${service} row`, async () => {
+      await this.waitForLoad();
+
+      const rows = await this.rows.all();
+      // start at 1 : skip table header
+      for (let i = 1; i < rows.length; i++) {
+        const text = await rows[i].getByRole('cell').nth(3).textContent();
+        if (text?.trim() === service) return rows[i];
+      }
+      throw new Error(`cannot found row for service ${service}`);
+    });
   }
 }


### PR DESCRIPTION
## Description

Enhance the e2e to now include the following scenario

1. Pull `quay.io/podman/hello:latest`
2. Install Podlet
3. Generate Image Quadlet for `quay.io/podman/hello:latest`
4. Assert quadlet is inactive by default
5. Open Quadlet Details
6. Start Image Quadlet
7. Assert `RUNNING`
8. Stop Image Quadlet
9. Assert not `RUNNING`
10. Remove Image Quadlet
11. Assert Quadlet list page is empty

## Related issues

Need rebase after https://github.com/podman-desktop/extension-podman-quadlet/pull/318
Fixes https://github.com/podman-desktop/extension-podman-quadlet/issues/317

## Testing

- GitHub actions should be ✅ 