### PR TITLE
feat(QuadletList): make quadlet name clickable

### DIFF
--- a/packages/frontend/src/lib/table/QuadletName.spec.ts
+++ b/packages/frontend/src/lib/table/QuadletName.spec.ts
@@ -16,16 +16,13 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-
 import '@testing-library/jest-dom/vitest';
 
 import { fireEvent, render } from '@testing-library/svelte';
 import { beforeEach, expect, test, vi } from 'vitest';
 import type { QuadletInfo } from '/@shared/src/models/quadlet-info';
 import { QuadletType } from '/@shared/src/utils/quadlet-type';
-import type {
-  ProviderContainerConnectionIdentifierInfo
-} from '/@shared/src/models/provider-container-connection-identifier-info';
+import type { ProviderContainerConnectionIdentifierInfo } from '/@shared/src/models/provider-container-connection-identifier-info';
 import QuadletName from '/@/lib/table/QuadletName.svelte';
 import { router } from 'tinro';
 
@@ -84,6 +81,8 @@ test('clicking on quadlet name should redirect to details page', async () => {
   await fireEvent.click(btn);
 
   await vi.waitFor(() => {
-    expect(router.goto).toHaveBeenCalledWith(`/quadlets/${PROVIDER_MOCK.providerId}/${PROVIDER_MOCK.name}/${QUADLET_MOCK.id}`);
+    expect(router.goto).toHaveBeenCalledWith(
+      `/quadlets/${PROVIDER_MOCK.providerId}/${PROVIDER_MOCK.name}/${QUADLET_MOCK.id}`,
+    );
   });
 });

--- a/packages/frontend/src/lib/table/QuadletName.spec.ts
+++ b/packages/frontend/src/lib/table/QuadletName.spec.ts
@@ -1,0 +1,89 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+
+import '@testing-library/jest-dom/vitest';
+
+import { fireEvent, render } from '@testing-library/svelte';
+import { beforeEach, expect, test, vi } from 'vitest';
+import type { QuadletInfo } from '/@shared/src/models/quadlet-info';
+import { QuadletType } from '/@shared/src/utils/quadlet-type';
+import type {
+  ProviderContainerConnectionIdentifierInfo
+} from '/@shared/src/models/provider-container-connection-identifier-info';
+import QuadletName from '/@/lib/table/QuadletName.svelte';
+import { router } from 'tinro';
+
+// mock utils
+vi.mock('tinro');
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+const PROVIDER_MOCK: ProviderContainerConnectionIdentifierInfo = {
+  name: 'podman-machine-default',
+  providerId: 'podman',
+};
+
+const QUADLET_MOCK: QuadletInfo = {
+  id: `dummy-id`,
+  service: 'foo.service',
+  content: 'dummy-content',
+  state: 'active',
+  path: `bar/foo.container`,
+  connection: PROVIDER_MOCK,
+  type: QuadletType.CONTAINER,
+};
+
+test('expect quadlet with service name to use it', () => {
+  const { getByRole } = render(QuadletName, {
+    object: QUADLET_MOCK,
+  });
+
+  const btn = getByRole('button', { name: 'quadlet name' });
+  expect(btn.textContent).toStrictEqual(QUADLET_MOCK.service);
+});
+
+test('expect quadlet without service name to use it', () => {
+  const { getByRole } = render(QuadletName, {
+    object: {
+      ...QUADLET_MOCK,
+      service: undefined,
+    },
+  });
+
+  const btn = getByRole('button', { name: 'quadlet name' });
+  expect(btn.textContent).toStrictEqual(QUADLET_MOCK.path);
+});
+
+test('clicking on quadlet name should redirect to details page', async () => {
+  const { getByRole } = render(QuadletName, {
+    object: {
+      ...QUADLET_MOCK,
+      service: undefined,
+    },
+  });
+
+  const btn = getByRole('button', { name: 'quadlet name' });
+  await fireEvent.click(btn);
+
+  await vi.waitFor(() => {
+    expect(router.goto).toHaveBeenCalledWith(`/quadlets/${PROVIDER_MOCK.providerId}/${PROVIDER_MOCK.name}/${QUADLET_MOCK.id}`);
+  });
+});

--- a/packages/frontend/src/lib/table/QuadletName.svelte
+++ b/packages/frontend/src/lib/table/QuadletName.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+import type { QuadletInfo } from '/@shared/src/models/quadlet-info';
+import { router } from 'tinro';
+
+interface Props {
+  object: QuadletInfo;
+}
+
+let { object }: Props = $props();
+
+let name = $derived(object.service ?? object.path);
+
+function openDetails(quadlet: QuadletInfo): void {
+  return router.goto(`/quadlets/${quadlet.connection.providerId}/${quadlet.connection.name}/${quadlet.id}`);
+}
+</script>
+
+<button class="hover:cursor-pointer" aria-label="quadlet name" onclick={openDetails.bind(undefined, object)}>
+  {name}
+</button>

--- a/packages/frontend/src/pages/QuadletsList.svelte
+++ b/packages/frontend/src/pages/QuadletsList.svelte
@@ -16,6 +16,7 @@ import type { ProviderContainerConnectionIdentifierInfo } from '/@shared/src/mod
 import EmptyQuadletList from '/@/lib/empty-screen/EmptyQuadletList.svelte';
 import { faTrash } from '@fortawesome/free-solid-svg-icons';
 import { get } from 'svelte/store';
+import QuadletName from '/@/lib/table/QuadletName.svelte';
 
 const columns = [
   new TableColumn<QuadletInfo>('Status', {
@@ -24,11 +25,10 @@ const columns = [
     align: 'center',
     comparator: (a, b): number => a.state.localeCompare(b.state),
   }),
-  new TableColumn<QuadletInfo, string>('Service name', {
-    renderer: TableSimpleColumn,
+  new TableColumn<QuadletInfo>('Service name', {
+    renderer: QuadletName,
     align: 'left',
     width: '200px',
-    renderMapping: (quadletsInfo: QuadletInfo): string => quadletsInfo.service ?? 'unknown',
     comparator: (a, b): number => a.id.localeCompare(b.id),
   }),
   new TableColumn<QuadletInfo, ProviderContainerConnectionIdentifierInfo>('Environment', {


### PR DESCRIPTION
## Description

Quadlet name on the Quadlet list were not clickable, and leading to inconstancies with the Podman Desktop application.

## Screenshot

https://github.com/user-attachments/assets/09224b4f-3473-42a2-995a-2de3544ef64c

## Related issues

Fixes https://github.com/podman-desktop/extension-podman-quadlet/issues/217

## Testing

- [x] unit tests has been provided