### PR TITLE
feat(podlet-js): adding image generator

### DIFF
--- a/packages/podlet-js/package.json
+++ b/packages/podlet-js/package.json
@@ -16,8 +16,11 @@
     "typescript": "5.7.3",
     "vite": "^6.0.11",
     "vitest": "^2.1.6",
-    "vite-plugin-dts": "^4.5.0"
+    "vite-plugin-dts": "^4.5.0",
+    "@podman-desktop/api": "^1.16.2"
   },
-  "dependencies": {},
+  "dependencies": {
+    "js-ini": "^1.6.0"
+  },
   "files": ["dist"]
 }

--- a/packages/podlet-js/src/images/image-generator.spec.ts
+++ b/packages/podlet-js/src/images/image-generator.spec.ts
@@ -1,0 +1,46 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import { readdir, readFile, access } from 'node:fs/promises';
+import { join } from 'node:path';
+import { test, expect, describe } from 'vitest';
+import { ImageGenerator } from './image-generator';
+
+const assetsDir = join(__dirname, './tests');
+
+describe('generate', async () => {
+  const folders = await readdir(assetsDir);
+
+  test.each(folders)('should generate correct output for %s', async folder => {
+    const folderPath = join(assetsDir, folder);
+    const imagePath = join(folderPath, 'image-inspect.json');
+    const expectedPath = join(folderPath, 'expect.ini');
+
+    await Promise.all(
+      [imagePath, expectedPath].map(async file => {
+        await access(file);
+      }),
+    );
+
+    const [image, expected] = await Promise.all([readFile(imagePath, 'utf-8'), readFile(expectedPath, 'utf-8')]);
+
+    const result = new ImageGenerator({
+      image: JSON.parse(image),
+    }).generate();
+    expect(result.trim()).toBe(expected.trim());
+  });
+});

--- a/packages/podlet-js/src/images/image-generator.ts
+++ b/packages/podlet-js/src/images/image-generator.ts
@@ -15,7 +15,27 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
+import { Generator } from '../utils/generator';
+import type { ImageInspectInfo } from '@podman-desktop/api';
+import { stringify } from 'js-ini';
+import type { ImageQuadlet } from '../models/image-quadlet';
 
-import { ImageGenerator } from './images/image-generator';
+interface Dependencies {
+  image: ImageInspectInfo;
+}
 
-export { ImageGenerator };
+export class ImageGenerator extends Generator<Dependencies> {
+  override generate(): string {
+    if (this.dependencies.image.RepoTags.length === 0) throw new Error('image selected does not have any repo tags.');
+
+    const image: ImageQuadlet = {
+      Image: {
+        Arch: this.dependencies.image.Architecture,
+        OS: this.dependencies.image.Os,
+        Image: this.dependencies.image.RepoTags[0],
+      },
+    };
+
+    return stringify(this.format(image));
+  }
+}

--- a/packages/podlet-js/src/images/tests/hello-world/expect.ini
+++ b/packages/podlet-js/src/images/tests/hello-world/expect.ini
@@ -1,0 +1,4 @@
+[Image]
+Arch=amd64
+OS=linux
+Image=quay.io/podman/hello:latest

--- a/packages/podlet-js/src/images/tests/hello-world/image-inspect.json
+++ b/packages/podlet-js/src/images/tests/hello-world/image-inspect.json
@@ -1,0 +1,97 @@
+{
+  "Id": "5dd467fce50b56951185da365b5feee75409968cbab5767b9b59e325fb2ecbc0",
+  "Digest": "sha256:43de9874507eaa8ffd88eac885b672b1dfc57cc583d9ad920850f97f19809f8f",
+  "RepoTags": [
+    "quay.io/podman/hello:latest"
+  ],
+  "RepoDigests": [
+    "quay.io/podman/hello@sha256:41316c18917a27a359ee3191fd8f43559d30592f82a144bbc59d9d44790f6e7a",
+    "quay.io/podman/hello@sha256:43de9874507eaa8ffd88eac885b672b1dfc57cc583d9ad920850f97f19809f8f"
+  ],
+  "Parent": "",
+  "Comment": "",
+  "Created": "2024-05-26T02:17:47.007111495Z",
+  "Config": {
+    "Env": [
+      "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+    ],
+    "Cmd": [
+      "/usr/local/bin/podman_hello_world"
+    ],
+    "Labels": {
+      "artist": "Máirín Ní Ḋuḃṫaiġ, X/Twitter:@mairin",
+      "io.buildah.version": "1.23.1",
+      "io.containers.capabilities": "sys_chroot",
+      "maintainer": "Podman Maintainers",
+      "org.opencontainers.image.description": "Hello world image with ascii art",
+      "org.opencontainers.image.documentation": "https://github.com/containers/PodmanHello/blob/76b262056eae09851d0a952d0f42b5bbeedde471/README.md",
+      "org.opencontainers.image.revision": "76b262056eae09851d0a952d0f42b5bbeedde471",
+      "org.opencontainers.image.source": "https://raw.githubusercontent.com/containers/PodmanHello/76b262056eae09851d0a952d0f42b5bbeedde471/Containerfile",
+      "org.opencontainers.image.title": "hello image",
+      "org.opencontainers.image.url": "https://github.com/containers/PodmanHello/actions/runs/9239934617"
+    }
+  },
+  "Version": "",
+  "Author": "",
+  "Architecture": "amd64",
+  "Os": "linux",
+  "Size": 786952,
+  "VirtualSize": 786952,
+  "GraphDriver": {
+    "Name": "overlay",
+    "Data": {
+      "UpperDir": "/home/axel7083/.local/share/containers/storage/overlay/2114fc8b70586b9325dde6fd26066d9951414dcdfb3995f41d51d1995cf3bd9d/diff",
+      "WorkDir": "/home/axel7083/.local/share/containers/storage/overlay/2114fc8b70586b9325dde6fd26066d9951414dcdfb3995f41d51d1995cf3bd9d/work"
+    }
+  },
+  "RootFS": {
+    "Type": "layers",
+    "Layers": [
+      "sha256:2114fc8b70586b9325dde6fd26066d9951414dcdfb3995f41d51d1995cf3bd9d"
+    ]
+  },
+  "Labels": {
+    "artist": "Máirín Ní Ḋuḃṫaiġ, X/Twitter:@mairin",
+    "io.buildah.version": "1.23.1",
+    "io.containers.capabilities": "sys_chroot",
+    "maintainer": "Podman Maintainers",
+    "org.opencontainers.image.description": "Hello world image with ascii art",
+    "org.opencontainers.image.documentation": "https://github.com/containers/PodmanHello/blob/76b262056eae09851d0a952d0f42b5bbeedde471/README.md",
+    "org.opencontainers.image.revision": "76b262056eae09851d0a952d0f42b5bbeedde471",
+    "org.opencontainers.image.source": "https://raw.githubusercontent.com/containers/PodmanHello/76b262056eae09851d0a952d0f42b5bbeedde471/Containerfile",
+    "org.opencontainers.image.title": "hello image",
+    "org.opencontainers.image.url": "https://github.com/containers/PodmanHello/actions/runs/9239934617"
+  },
+  "Annotations": {},
+  "ManifestType": "application/vnd.docker.distribution.manifest.v2+json",
+  "User": "",
+  "History": [
+    {
+      "created": "2024-05-26T02:17:46.895294914Z",
+      "created_by": "/bin/sh -c #(nop) LABEL maintainer=\"Podman Maintainers\"",
+      "empty_layer": true
+    },
+    {
+      "created": "2024-05-26T02:17:46.895306986Z",
+      "created_by": "/bin/sh -c #(nop) LABEL artist=\"Máirín Ní Ḋuḃṫaiġ, X/Twitter:@mairin\"",
+      "empty_layer": true
+    },
+    {
+      "created": "2024-05-26T02:17:46.895318057Z",
+      "created_by": "/bin/sh -c #(nop) LABEL io.containers.capabilities=\"sys_chroot\"",
+      "empty_layer": true
+    },
+    {
+      "created": "2024-05-26T02:17:47.00637389Z",
+      "created_by": "/bin/sh -c #(nop) COPY file:dcd0ec8c82666e48d3c5cfa9555c2b9c61a535c7697ac25beb65cc991d33833c in /usr/local/bin/podman_hello_world ",
+      "empty_layer": true
+    },
+    {
+      "created": "2024-05-26T02:17:47.011005044Z",
+      "created_by": "/bin/sh -c #(nop) CMD [\"/usr/local/bin/podman_hello_world\"]"
+    }
+  ],
+  "NamesHistory": [
+    "quay.io/podman/hello:latest"
+  ]
+}

--- a/packages/podlet-js/src/images/tests/nginx/expect.ini
+++ b/packages/podlet-js/src/images/tests/nginx/expect.ini
@@ -1,0 +1,4 @@
+[Image]
+Arch=amd64
+OS=linux
+Image=docker.io/library/nginx:latest

--- a/packages/podlet-js/src/images/tests/nginx/image-inspect.json
+++ b/packages/podlet-js/src/images/tests/nginx/image-inspect.json
@@ -1,0 +1,181 @@
+
+{
+  "Id": "9bea9f2796e236cb18c2b3ad561ff29f655d1001f9ec7247a0bc5e08d25652a1",
+  "Digest": "sha256:2426c815287ed75a3a33dd28512eba4f0f783946844209ccf3fa8990817a4eb9",
+  "RepoTags": [
+    "docker.io/library/nginx:latest"
+  ],
+  "RepoDigests": [
+    "docker.io/library/nginx@sha256:0a399eb16751829e1af26fea27b20c3ec28d7ab1fb72182879dcae1cca21206a",
+    "docker.io/library/nginx@sha256:2426c815287ed75a3a33dd28512eba4f0f783946844209ccf3fa8990817a4eb9"
+  ],
+  "Parent": "",
+  "Comment": "debuerreotype 0.15",
+  "Created": "2024-11-26T18:42:08Z",
+  "Config": {
+    "ExposedPorts": {
+      "80/tcp": {}
+    },
+    "Env": [
+      "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+      "NGINX_VERSION=1.27.3",
+      "NJS_VERSION=0.8.7",
+      "NJS_RELEASE=1~bookworm",
+      "PKG_RELEASE=1~bookworm",
+      "DYNPKG_RELEASE=1~bookworm"
+    ],
+    "Entrypoint": [
+      "/docker-entrypoint.sh"
+    ],
+    "Cmd": [
+      "nginx",
+      "-g",
+      "daemon off;"
+    ],
+    "Labels": {
+      "maintainer": "NGINX Docker Maintainers <docker-maint@nginx.com>"
+    },
+    "StopSignal": "SIGQUIT"
+  },
+  "Version": "",
+  "Author": "",
+  "Architecture": "amd64",
+  "Os": "linux",
+  "Size": 195872148,
+  "VirtualSize": 195872148,
+  "GraphDriver": {
+    "Name": "overlay",
+    "Data": {
+      "LowerDir": "/home/axel7083/.local/share/containers/storage/overlay/ef166b6393d49f23cddd039aaa88ee02583a61ebfed83afe923730b51a43a7db/diff:/home/axel7083/.local/share/containers/storage/overlay/f9ae406619e482630b5fac194b9d30810e6beb254880b2122155ce4603203d08/diff:/home/axel7083/.local/share/containers/storage/overlay/0a65c2ad8264f4a8c1052e02aa28e56d7829f0d771b3e3a3af395c217d3df032/diff:/home/axel7083/.local/share/containers/storage/overlay/ef8d96358bf8667c3b99fc77805155cb61c1a364422d033f7348da66d1047d8c/diff:/home/axel7083/.local/share/containers/storage/overlay/66c1639cbd8b26b2e2c2b5a6230846ee12e7c98df91b8b877c7c260efbbb31ae/diff:/home/axel7083/.local/share/containers/storage/overlay/f5fe472da25334617e6e6467c7ebce41e0ae5580e5bd0ecbf0d573bacd560ecb/diff",
+      "UpperDir": "/home/axel7083/.local/share/containers/storage/overlay/8eb798f76eddf8df37c7f39a47bb2f9ca6eb929ae1d2224b265958d81d6cd92b/diff",
+      "WorkDir": "/home/axel7083/.local/share/containers/storage/overlay/8eb798f76eddf8df37c7f39a47bb2f9ca6eb929ae1d2224b265958d81d6cd92b/work"
+    }
+  },
+  "RootFS": {
+    "Type": "layers",
+    "Layers": [
+      "sha256:f5fe472da25334617e6e6467c7ebce41e0ae5580e5bd0ecbf0d573bacd560ecb",
+      "sha256:88ebb510d2fb3ed50f4268455a38443074cad5c6957f6d2cd0126c899a159e6e",
+      "sha256:9431321431991c4e64246007e04602160bca8984439ff96461fb992072dd49af",
+      "sha256:32c977818204dc910140b3b7abcad06a6613dd1f511ce8f33626a364a3bb68b6",
+      "sha256:541cf9cf006d6c9920e5897bf63a4dce0ae1a8388bc82bfa1abedc48b8eb1de9",
+      "sha256:58045dd06e5b2c1220ab200c36b450ce3adbfd3fa0f8e3c2c17ffaf7f2906455",
+      "sha256:b57b5eac2941c7c1f1f5bc2391123e553d0082eb8e1c6675101aab47a11b26ee"
+    ]
+  },
+  "Labels": {
+    "maintainer": "NGINX Docker Maintainers <docker-maint@nginx.com>"
+  },
+  "Annotations": {
+    "com.docker.official-images.bashbrew.arch": "amd64",
+    "org.opencontainers.image.base.digest": "sha256:88615a98ed57334c7adcf5de988ee406b686c263bb7d324cd7b75db01f980503",
+    "org.opencontainers.image.base.name": "debian:bookworm-slim",
+    "org.opencontainers.image.created": "2024-11-26T18:42:08Z",
+    "org.opencontainers.image.revision": "d21b4f2d90a1abb712a610678872e804267f4815",
+    "org.opencontainers.image.source": "https://github.com/nginxinc/docker-nginx.git#d21b4f2d90a1abb712a610678872e804267f4815:mainline/debian",
+    "org.opencontainers.image.url": "https://hub.docker.com/_/nginx",
+    "org.opencontainers.image.version": "1.27.3"
+  },
+  "ManifestType": "application/vnd.oci.image.manifest.v1+json",
+  "User": "",
+  "History": [
+    {
+      "created": "2024-11-26T18:42:08Z",
+      "created_by": "# debian.sh --arch 'amd64' out/ 'bookworm' '@1736726400'",
+      "comment": "debuerreotype 0.15"
+    },
+    {
+      "created": "2024-11-26T18:42:08Z",
+      "created_by": "LABEL maintainer=NGINX Docker Maintainers <docker-maint@nginx.com>",
+      "comment": "buildkit.dockerfile.v0",
+      "empty_layer": true
+    },
+    {
+      "created": "2024-11-26T18:42:08Z",
+      "created_by": "ENV NGINX_VERSION=1.27.3",
+      "comment": "buildkit.dockerfile.v0",
+      "empty_layer": true
+    },
+    {
+      "created": "2024-11-26T18:42:08Z",
+      "created_by": "ENV NJS_VERSION=0.8.7",
+      "comment": "buildkit.dockerfile.v0",
+      "empty_layer": true
+    },
+    {
+      "created": "2024-11-26T18:42:08Z",
+      "created_by": "ENV NJS_RELEASE=1~bookworm",
+      "comment": "buildkit.dockerfile.v0",
+      "empty_layer": true
+    },
+    {
+      "created": "2024-11-26T18:42:08Z",
+      "created_by": "ENV PKG_RELEASE=1~bookworm",
+      "comment": "buildkit.dockerfile.v0",
+      "empty_layer": true
+    },
+    {
+      "created": "2024-11-26T18:42:08Z",
+      "created_by": "ENV DYNPKG_RELEASE=1~bookworm",
+      "comment": "buildkit.dockerfile.v0",
+      "empty_layer": true
+    },
+    {
+      "created": "2024-11-26T18:42:08Z",
+      "created_by": "RUN /bin/sh -c set -x     && groupadd --system --gid 101 nginx     && useradd --system --gid nginx --no-create-home --home /nonexistent --comment \"nginx user\" --shell /bin/false --uid 101 nginx     && apt-get update     && apt-get install --no-install-recommends --no-install-suggests -y gnupg1 ca-certificates     &&     NGINX_GPGKEYS=\"573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62 8540A6F18833A80E9C1653A42FD21310B49F6B46 9E9BE90EACBCDE69FE9B204CBCDCD8A38D88A2B3\";     NGINX_GPGKEY_PATH=/etc/apt/keyrings/nginx-archive-keyring.gpg;     export GNUPGHOME=\"$(mktemp -d)\";     found='';     for NGINX_GPGKEY in $NGINX_GPGKEYS; do     for server in         hkp://keyserver.ubuntu.com:80         pgp.mit.edu     ; do         echo \"Fetching GPG key $NGINX_GPGKEY from $server\";         gpg1 --keyserver \"$server\" --keyserver-options timeout=10 --recv-keys \"$NGINX_GPGKEY\" && found=yes && break;     done;     test -z \"$found\" && echo >&2 \"error: failed to fetch GPG key $NGINX_GPGKEY\" && exit 1;     done;     gpg1 --export \"$NGINX_GPGKEYS\" > \"$NGINX_GPGKEY_PATH\" ;     rm -rf \"$GNUPGHOME\";     apt-get remove --purge --auto-remove -y gnupg1 && rm -rf /var/lib/apt/lists/*     && dpkgArch=\"$(dpkg --print-architecture)\"     && nginxPackages=\"         nginx=${NGINX_VERSION}-${PKG_RELEASE}         nginx-module-xslt=${NGINX_VERSION}-${DYNPKG_RELEASE}         nginx-module-geoip=${NGINX_VERSION}-${DYNPKG_RELEASE}         nginx-module-image-filter=${NGINX_VERSION}-${DYNPKG_RELEASE}         nginx-module-njs=${NGINX_VERSION}+${NJS_VERSION}-${NJS_RELEASE}     \"     && case \"$dpkgArch\" in         amd64|arm64)             echo \"deb [signed-by=$NGINX_GPGKEY_PATH] https://nginx.org/packages/mainline/debian/ bookworm nginx\" >> /etc/apt/sources.list.d/nginx.list             && apt-get update             ;;         *)             tempDir=\"$(mktemp -d)\"             && chmod 777 \"$tempDir\"                         && savedAptMark=\"$(apt-mark showmanual)\"                         && apt-get update             && apt-get install --no-install-recommends --no-install-suggests -y                 curl                 devscripts                 equivs                 git                 libxml2-utils                 lsb-release                 xsltproc             && (                 cd \"$tempDir\"                 && REVISION=\"${NGINX_VERSION}-${PKG_RELEASE}\"                 && REVISION=${REVISION%~*}                 && curl -f -L -O https://github.com/nginx/pkg-oss/archive/${REVISION}.tar.gz                 && PKGOSSCHECKSUM=\"5617feecfb441cd972b9ac51a2fd78384a3d2bde2f399163be0746d44ec8f7d8c47234af4f6b0012667c3d0446cced521f55f8f71254415e3766c2e3802bf960 *${REVISION}.tar.gz\"                 && if [ \"$(openssl sha512 -r ${REVISION}.tar.gz)\" = \"$PKGOSSCHECKSUM\" ]; then                     echo \"pkg-oss tarball checksum verification succeeded!\";                 else                     echo \"pkg-oss tarball checksum verification failed!\";                     exit 1;                 fi                 && tar xzvf ${REVISION}.tar.gz                 && cd pkg-oss-${REVISION}                 && cd debian                 && for target in base module-geoip module-image-filter module-njs module-xslt; do                     make rules-$target;                     mk-build-deps --install --tool=\"apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends --yes\"                         debuild-$target/nginx-$NGINX_VERSION/debian/control;                 done                 && make base module-geoip module-image-filter module-njs module-xslt             )                         && apt-mark showmanual | xargs apt-mark auto > /dev/null             && { [ -z \"$savedAptMark\" ] || apt-mark manual $savedAptMark; }                         && ls -lAFh \"$tempDir\"             && ( cd \"$tempDir\" && dpkg-scanpackages . > Packages )             && grep '^Package: ' \"$tempDir/Packages\"             && echo \"deb [ trusted=yes ] file://$tempDir ./\" > /etc/apt/sources.list.d/temp.list             && apt-get -o Acquire::GzipIndexes=false update             ;;     esac         && apt-get install --no-install-recommends --no-install-suggests -y                         $nginxPackages                         gettext-base                         curl     && apt-get remove --purge --auto-remove -y && rm -rf /var/lib/apt/lists/* /etc/apt/sources.list.d/nginx.list         && if [ -n \"$tempDir\" ]; then         apt-get purge -y --auto-remove         && rm -rf \"$tempDir\" /etc/apt/sources.list.d/temp.list;     fi     && ln -sf /dev/stdout /var/log/nginx/access.log     && ln -sf /dev/stderr /var/log/nginx/error.log     && mkdir /docker-entrypoint.d # buildkit",
+      "comment": "buildkit.dockerfile.v0"
+    },
+    {
+      "created": "2024-11-26T18:42:08Z",
+      "created_by": "COPY docker-entrypoint.sh / # buildkit",
+      "comment": "buildkit.dockerfile.v0"
+    },
+    {
+      "created": "2024-11-26T18:42:08Z",
+      "created_by": "COPY 10-listen-on-ipv6-by-default.sh /docker-entrypoint.d # buildkit",
+      "comment": "buildkit.dockerfile.v0"
+    },
+    {
+      "created": "2024-11-26T18:42:08Z",
+      "created_by": "COPY 15-local-resolvers.envsh /docker-entrypoint.d # buildkit",
+      "comment": "buildkit.dockerfile.v0"
+    },
+    {
+      "created": "2024-11-26T18:42:08Z",
+      "created_by": "COPY 20-envsubst-on-templates.sh /docker-entrypoint.d # buildkit",
+      "comment": "buildkit.dockerfile.v0"
+    },
+    {
+      "created": "2024-11-26T18:42:08Z",
+      "created_by": "COPY 30-tune-worker-processes.sh /docker-entrypoint.d # buildkit",
+      "comment": "buildkit.dockerfile.v0"
+    },
+    {
+      "created": "2024-11-26T18:42:08Z",
+      "created_by": "ENTRYPOINT [\"/docker-entrypoint.sh\"]",
+      "comment": "buildkit.dockerfile.v0",
+      "empty_layer": true
+    },
+    {
+      "created": "2024-11-26T18:42:08Z",
+      "created_by": "EXPOSE map[80/tcp:{}]",
+      "comment": "buildkit.dockerfile.v0",
+      "empty_layer": true
+    },
+    {
+      "created": "2024-11-26T18:42:08Z",
+      "created_by": "STOPSIGNAL SIGQUIT",
+      "comment": "buildkit.dockerfile.v0",
+      "empty_layer": true
+    },
+    {
+      "created": "2024-11-26T18:42:08Z",
+      "created_by": "CMD [\"nginx\" \"-g\" \"daemon off;\"]",
+      "comment": "buildkit.dockerfile.v0",
+      "empty_layer": true
+    }
+  ],
+  "NamesHistory": [
+    "docker.io/library/nginx:latest"
+  ]
+}

--- a/packages/podlet-js/src/models/image-quadlet.ts
+++ b/packages/podlet-js/src/models/image-quadlet.ts
@@ -1,0 +1,107 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import type { ServiceQuadlet } from './service-quadlet';
+
+/**
+ * Learn more about Image Quadlet https://docs.podman.io/en/latest/markdown/podman-systemd.unit.5.html#image-units-image
+ */
+export interface ImageQuadlet {
+  Service?: ServiceQuadlet;
+  Image: {
+    /**
+     * All tagged images in the repository are pulled.
+     *
+     * This is equivalent to the Podman --all-tags option.
+     */
+    AllTags?: boolean;
+    /**
+     * Override the architecture, defaults to hosts, of the image to be pulled.
+     *
+     * This is equivalent to the Podman --arch option.
+     */
+    Arch?: string;
+    /**
+     * Path of the authentication file.
+     *
+     * This is equivalent to the Podman --authfile option.
+     */
+    AuthFile?: string;
+    /**
+     * Use certificates at path (*.crt, *.cert, *.key) to connect to the registry.
+     *
+     * This is equivalent to the Podman --cert-dir option.
+     */
+    CertDir?: string;
+    /**
+     * Load the specified containers.conf(5) module.
+     *
+     * Equivalent to the Podman --module option.
+     */
+    ContainersConfModule?: Array<string>;
+    /**
+     * The [username[:password]] to use to authenticate with the registry, if required.
+     *
+     * This is equivalent to the Podman --creds option.
+     */
+    Creds?: string;
+    /**
+     * The [key[:passphrase]] to be used for decryption of images.
+     *
+     * This is equivalent to the Podman --decryption-key option.
+     */
+    DecryptionKey?: string;
+    /**
+     * This key contains a list of arguments passed directly between podman and image in the generated file. It can be used to access Podman features otherwise unsupported by the generator. Since the generator is unaware of what unexpected interactions can be caused by these arguments, it is not recommended to use this option.
+     *
+     * The format of this is a space separated list of arguments, which can optionally be individually escaped to allow inclusion of whitespace and other control characters.
+     */
+    GlobalArgs?: Array<string>;
+    /**
+     * The image to pull. It is recommended to use a fully qualified image name rather than a short name, both for performance and robustness reasons.
+     *
+     * The format of the name is the same as when passed to podman pull. So, it supports using :tag or digests to guarantee the specific image version.
+     */
+    Image?: string;
+    /**
+     * Actual FQIN of the referenced Image.
+     * Only meaningful when source is a file or directory archive.
+     */
+    ImageTag?: string;
+    /**
+     * Override the OS, defaults to hosts, of the image to be pulled.
+     * This is equivalent to the Podman `--os` option.
+     */
+    OS?: string;
+    /**
+     * This key contains a list of arguments passed directly to the end of the podman image pull command in the generated file
+     */
+    PodmanArgs?: Array<string>;
+    /**
+     * Require HTTPS and verification of certificates when contacting registries.
+     *
+     * This is equivalent to the Podman --tls-verify option.
+     */
+    TLSVerify?: string;
+    /**
+     * Override the default architecture variant of the container image.
+     *
+     * This is equivalent to the Podman --variant option.
+     */
+    Variant?: string;
+  };
+}

--- a/packages/podlet-js/src/models/service-quadlet.ts
+++ b/packages/podlet-js/src/models/service-quadlet.ts
@@ -15,7 +15,21 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
+export type ServiceRestartPolicy =
+  | 'no'
+  | 'on-success'
+  | 'on-failure'
+  | 'on-abnormal'
+  | 'on-watchdog'
+  | 'on-abort'
+  | 'always';
 
-import { ImageGenerator } from './images/image-generator';
-
-export { ImageGenerator };
+/**
+ * Learn more https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html
+ */
+export interface ServiceQuadlet {
+  /**
+   * Configures whether the service shall be restarted when the service process exits, is killed, or a timeout is reached.
+   */
+  Restart?: ServiceRestartPolicy;
+}

--- a/packages/podlet-js/src/utils/generator.ts
+++ b/packages/podlet-js/src/utils/generator.ts
@@ -1,0 +1,53 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import type { IIniObject } from 'js-ini/src/interfaces/ini-object';
+
+export abstract class Generator<T> {
+  constructor(protected dependencies: T) {}
+
+  /**
+   * The object is under the format `{ Container: { Annotation: Array<string>, ... } }` but js-ini
+   * need to have `{ Container: Array<string> }` to convert it to ini.
+   *
+   * See https://github.com/Sdju/js-ini/pull/37 for future improvement
+   *
+   * @protected
+   * @param obj
+   */
+  protected format(obj: unknown): IIniObject {
+    if (!obj || typeof obj !== 'object') throw new Error(`cannot format object of type ${typeof obj}`);
+
+    return Object.fromEntries(
+      Object.entries(obj).map(([key, value]) => {
+        return [
+          key,
+          Object.entries(value).reduce((accumulator, [item, content]) => {
+            if (Array.isArray(content)) {
+              accumulator.push(...content.map(v => `${item}=${v}`));
+            } else {
+              accumulator.push(`${item}=${content}`);
+            }
+            return accumulator;
+          }, [] as string[]),
+        ];
+      }),
+    );
+  }
+
+  abstract generate(): string;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -262,7 +262,14 @@ importers:
         version: 2.1.6(@types/node@20.17.19)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.29.1)(yaml@2.6.1)
 
   packages/podlet-js:
+    dependencies:
+      js-ini:
+        specifier: ^1.6.0
+        version: 1.6.0
     devDependencies:
+      '@podman-desktop/api':
+        specifier: ^1.16.2
+        version: 1.16.2
       typescript:
         specifier: 5.7.3
         version: 5.7.3


### PR DESCRIPTION
## Description

Adding `ImageGenerator` to `podlet-js` package: transforming an [ImageInspectInfo](https://podman-desktop.io/api/interfaces/ImageInspectInfo) into an Image Quadlet.

## Usage

```ts
// should run inside a podman desktop extension
import { ImageGenerator } from 'podlet-js';
import { containerEngine } from '@podman-desktop/api';

async function demo(): Promise<string> {
  // Get the image inspect from Podman Desktop api
  const imageInfo = await containerEngine.getImageInspect(<engine-id>, <image-id>);

  // Use podlet-js ImageGenerator to generate an ImageQuadlet
  const generator =  new ImageGenerator({ image: imageInfo });
  return generator.generate();
}
```

## Related issue

Part of https://github.com/podman-desktop/extension-podman-quadlet/issues/298

## Testing

- [x] unit tests has been provided

**Details**

In the `packages/podlet-js/src/images/tests` there are several folders; the structure of each folder in it is the following

```
.
└── tests/
    └── <test-case>/
        ├── expect.ini
        └── image-inspect.json
```

The file `packages/podlet-js/src/images/image-generator.spec.ts` will read the `image-inspect.json` generate a image quadlet, and ensure it match the `expect.ini`.