### PR TITLE
feat: adding `error` state to Quadlet & QuadletInfo models

### DIFF
--- a/packages/backend/src/models/quadlet.ts
+++ b/packages/backend/src/models/quadlet.ts
@@ -2,6 +2,7 @@
  * @author axel7083
  */
 import type { QuadletType } from '/@shared/src/utils/quadlet-type';
+import type { QuadletState } from '/@shared/src/models/quadlet-info';
 
 export interface Quadlet {
   /**
@@ -26,7 +27,7 @@ export interface Quadlet {
   /**
    * State of the quadlet
    */
-  state: 'active' | 'inactive' | 'deleting' | 'unknown';
+  state: QuadletState;
   /**
    * quadlet have a type based on their extension (.container, .image etc.)
    */

--- a/packages/frontend/src/lib/table/QuadletStatus.spec.ts
+++ b/packages/frontend/src/lib/table/QuadletStatus.spec.ts
@@ -1,0 +1,92 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render } from '@testing-library/svelte';
+import { beforeEach, expect, test, vi } from 'vitest';
+import type { QuadletState, QuadletInfo } from '/@shared/src/models/quadlet-info';
+
+import QuadletStatus from '/@/lib/table/QuadletStatus.svelte';
+import type { ProviderContainerConnectionIdentifierInfo } from '/@shared/src/models/provider-container-connection-identifier-info';
+import { QuadletType } from '/@shared/src/utils/quadlet-type';
+import { StatusIcon } from '@podman-desktop/ui-svelte';
+
+vi.mock('@podman-desktop/ui-svelte');
+
+const PROVIDER_MOCK: ProviderContainerConnectionIdentifierInfo = {
+  name: 'podman-machine-default',
+  providerId: 'podman',
+};
+
+const QUADLET_MOCK: QuadletInfo = {
+  id: `foo.container`,
+  content: 'dummy-content',
+  state: 'active',
+  path: `bar/foo.container`,
+  connection: PROVIDER_MOCK,
+  type: QuadletType.CONTAINER,
+};
+
+type TestCase = {
+  state: QuadletState;
+  status: string;
+};
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+test.each<TestCase>([
+  {
+    state: 'active',
+    status: 'RUNNING',
+  },
+  {
+    state: 'deleting',
+    status: 'DELETING',
+  },
+  {
+    state: 'error',
+    status: 'DEGRADED',
+  },
+  {
+    state: 'unknown',
+    status: '',
+  },
+  {
+    state: 'inactive',
+    status: '',
+  },
+])('Quadlet with state $state should display status $status', async ({ state, status }) => {
+  render(QuadletStatus, {
+    object: {
+      ...QUADLET_MOCK,
+      state,
+    },
+  });
+
+  await vi.waitFor(() => {
+    expect(StatusIcon).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        status: status,
+      }),
+    );
+  });
+});

--- a/packages/frontend/src/lib/table/QuadletStatus.svelte
+++ b/packages/frontend/src/lib/table/QuadletStatus.svelte
@@ -12,10 +12,16 @@ interface Props {
 let { object }: Props = $props();
 
 let status: string = $derived.by(() => {
-  if (object.state === 'active') {
-    return 'RUNNING';
-  } else {
-    return '';
+  switch (object.state) {
+    case 'active':
+      return 'RUNNING';
+    case 'deleting':
+      return 'DELETING';
+    case 'error':
+      return 'DEGRADED';
+    case 'unknown':
+    case 'inactive':
+      return '';
   }
 });
 

--- a/packages/shared/src/models/quadlet-info.ts
+++ b/packages/shared/src/models/quadlet-info.ts
@@ -4,6 +4,8 @@
 import type { ProviderContainerConnectionIdentifierInfo } from './provider-container-connection-identifier-info';
 import type { QuadletType } from '../utils/quadlet-type';
 
+export type QuadletState = 'active' | 'inactive' | 'deleting' | 'unknown' | 'error';
+
 export interface QuadletInfo {
   /**
    * UUID to internally identify the quadlet
@@ -27,7 +29,7 @@ export interface QuadletInfo {
   /**
    * State of the quadlet
    */
-  state: 'active' | 'inactive' | 'deleting' | 'error' | 'unknown';
+  state: QuadletState;
   /**
    * Associate connection to the quadlet
    */


### PR DESCRIPTION
## Description

To be able to properly display that a Quadlet is in an invalid state, we should have a dedicated `error` state.

> ℹ️ this PR does not include any logic to set the state to error, a follow-up PR to fix https://github.com/podman-desktop/extension-podman-quadlet/issues/304 will do it.

## Screenshot

![image](https://github.com/user-attachments/assets/dd8cc1ef-2222-4b11-a173-fea0f1e04e90)

## Related issues

Part of https://github.com/podman-desktop/extension-podman-quadlet/issues/304

## Testing

- [x] unit tests have been provided