### PR TITLE
fix(ui): quadlet name column text ellipsis

### DIFF
--- a/packages/frontend/src/lib/table/QuadletName.svelte
+++ b/packages/frontend/src/lib/table/QuadletName.svelte
@@ -15,6 +15,9 @@ function openDetails(quadlet: QuadletInfo): void {
 }
 </script>
 
-<button class="hover:cursor-pointer" aria-label="quadlet name" onclick={openDetails.bind(undefined, object)}>
+<button
+  class="hover:cursor-pointer w-full overflow-hidden text-ellipsis"
+  aria-label="quadlet name"
+  onclick={openDetails.bind(undefined, object)}>
   {name}
 </button>

--- a/packages/frontend/src/lib/table/QuadletName.svelte
+++ b/packages/frontend/src/lib/table/QuadletName.svelte
@@ -16,6 +16,7 @@ function openDetails(quadlet: QuadletInfo): void {
 </script>
 
 <button
+  title={name}
   class="hover:cursor-pointer w-full overflow-hidden text-ellipsis"
   aria-label="quadlet name"
   onclick={openDetails.bind(undefined, object)}>


### PR DESCRIPTION
## Description

Following https://github.com/podman-desktop/extension-podman-quadlet/pull/327 I noticed that when the quadlet name is using the path, and not the service name (when the Quadlet is in an error state), we have the text that overflow.

**Before**

![image](https://github.com/user-attachments/assets/bc527c01-cb71-4132-9dce-f879c5075557)

**After**

![image](https://github.com/user-attachments/assets/e3389dee-fb96-4861-b869-ac1da1628bce)

