### PR TITLE
refactor(backend): extract path parsing logic

### DIFF
--- a/packages/backend/src/utils/parsers/quadlet-extension-parser.spec.ts
+++ b/packages/backend/src/utils/parsers/quadlet-extension-parser.spec.ts
@@ -1,0 +1,38 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { test, expect } from 'vitest';
+import { QuadletType } from '/@shared/src/utils/quadlet-type';
+import { QuadletExtensionParser } from './quadlet-extension-parser';
+
+test.each<QuadletType>(Object.values(QuadletType))('parsing file with extension %s', (type: QuadletType) => {
+  const result = new QuadletExtensionParser(`/example/foo.${type.toLowerCase()}`).parse();
+  expect(result).toStrictEqual(type);
+});
+
+test('path without extension should throw an error', () => {
+  expect(() => {
+    new QuadletExtensionParser(`/example/foo`).parse();
+  }).toThrowError('cannot find quadlet type from path: /example/foo');
+});
+
+test('unknown extension should throw an error', () => {
+  expect(() => {
+    new QuadletExtensionParser(`/example/foo.txt`).parse();
+  }).toThrowError('cannot find quadlet type from path: /example/foo.txt');
+});

--- a/packages/backend/src/utils/parsers/quadlet-extension-parser.ts
+++ b/packages/backend/src/utils/parsers/quadlet-extension-parser.ts
@@ -1,0 +1,37 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { Parser } from './iparser';
+import { QuadletType } from '/@shared/src/utils/quadlet-type';
+import { basename } from 'node:path/posix';
+
+export class QuadletExtensionParser extends Parser<string, QuadletType> {
+  constructor(path: string) {
+    super(path);
+  }
+
+  override parse(): QuadletType {
+    const extension = basename(this.content).split('.').pop();
+    if (!extension) throw new Error(`path provided do not contain any file extension: ${this.content}`);
+
+    const type: QuadletType | undefined = Object.values(QuadletType).find(type => extension === type.toLowerCase());
+    if (!type) throw new Error(`cannot find quadlet type from path: ${this.content}`);
+
+    return type;
+  }
+}

--- a/packages/backend/src/utils/parsers/quadlet-unit-parser.ts
+++ b/packages/backend/src/utils/parsers/quadlet-unit-parser.ts
@@ -5,7 +5,8 @@
 import { Parser } from './iparser';
 import { parse } from 'js-ini';
 import type { Quadlet } from '../../models/quadlet';
-import { QuadletType } from '/@shared/src/utils/quadlet-type';
+import type { QuadletType } from '/@shared/src/utils/quadlet-type';
+import { QuadletExtensionParser } from './quadlet-extension-parser';
 import { randomUUID } from 'node:crypto';
 
 interface Unit {
@@ -37,10 +38,8 @@ export class QuadletUnitParser extends Parser<string, Quadlet> {
       comment: ['#', ';'],
     });
     const unit = this.toUnit(raw['Unit'] as Record<string, string>);
-
-    const extension = unit.SourcePath.split('.').pop();
-    const type: QuadletType | undefined = Object.values(QuadletType).find(type => extension === type.toLowerCase());
-    if (!type) throw new Error(`cannot found quadlet type for file ${unit.SourcePath}`);
+    // extract the type from the path
+    const type: QuadletType = new QuadletExtensionParser(unit.SourcePath).parse();
 
     return {
       path: unit.SourcePath,


### PR DESCRIPTION
## Description

To complete https://github.com/podman-desktop/extension-podman-quadlet/issues/304 I need to enhance the `QuadletDryRunParser`, which will need to determine a QuadletType given a quadlet path (E.g. `/foo/bar.image` => image quadlet).

Therefore extracting the logic from the `QuadletUnitParser` into a dedicated `QuadletExtensionParser` parser.

## Related issue

Required for https://github.com/podman-desktop/extension-podman-quadlet/issues/304

## Testing

- [x] unit tests have been provided