### PR TITLE
refactor(backend): extract isRunError logic

### DIFF
--- a/packages/backend/src/utils/run-error.spec.ts
+++ b/packages/backend/src/utils/run-error.spec.ts
@@ -1,0 +1,61 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import { expect, test } from 'vitest';
+import { isRunError } from './run-error';
+
+test.each<{
+  value: unknown;
+  result: boolean;
+}>([
+  {
+    value: undefined,
+    result: false,
+  },
+  {
+    value: {},
+    result: false,
+  },
+  {
+    value: {
+      stdout: '',
+      stderr: '',
+      command: '',
+    },
+    result: false,
+  },
+  {
+    value: {
+      stdout: '',
+      stderr: '',
+      command: '',
+      exitCode: 0,
+    },
+    result: false,
+  },
+  {
+    value: {
+      stdout: '',
+      stderr: '',
+      command: '',
+      exitCode: 1,
+    },
+    result: true,
+  },
+])('expect isRunError($value) to be $result', ({ value, result }) => {
+  expect(isRunError(value)).toBe(result);
+});

--- a/packages/backend/src/utils/run-error.ts
+++ b/packages/backend/src/utils/run-error.ts
@@ -1,0 +1,22 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import type { RunError } from '@podman-desktop/api';
+
+export function isRunError(value: unknown): value is RunError {
+  return !!value && typeof value === 'object' && 'exitCode' in value && value.exitCode !== 0;
+}


### PR DESCRIPTION
## Description

To be able to properly parse the `quadlet -dryrun` I will need to parse the `stderr` of it when it return non-zero exit code. We already have similar logic for systemctl, which return non-zero code when getting the status of a service that is not inactive.

This PR do not introduce any new feature, it extract the existing logic, and improve the typing of the systemctl logic for later reuse for quadlet executable.

## Related issue

Required for https://github.com/podman-desktop/extension-podman-quadlet/issues/304

## Testing

- [x] unit tests has been provided 