### PR TITLE
feat: properly parse quadlet -dryrun stderr

### DIFF
--- a/packages/backend/src/services/podman-service.ts
+++ b/packages/backend/src/services/podman-service.ts
@@ -204,10 +204,14 @@ export class PodmanService extends PodmanHelper implements Disposable, AsyncInit
     logger?: Logger;
     token?: CancellationToken;
     env?: Record<string, string>;
-  }): Promise<RunResult> {
+  }): Promise<RunResult | RunError> {
     return this.executeWrapper({
       ...options,
       command: '/usr/libexec/podman/quadlet',
+    }).catch((err: unknown) => {
+      // check err is an RunError
+      if (isRunError(err)) return err;
+      throw err;
     });
   }
 

--- a/packages/backend/src/services/quadlet-service.ts
+++ b/packages/backend/src/services/quadlet-service.ts
@@ -123,6 +123,7 @@ export class QuadletService extends QuadletHelper implements Disposable, AsyncIn
       connection: provider,
       args: ['-version'],
     });
+    if (result.exitCode) throw new Error(`cannot get quadlet version (${result.exitCode}): ${result.stdout}`);
     return result.stdout;
   }
 
@@ -142,7 +143,7 @@ export class QuadletService extends QuadletHelper implements Disposable, AsyncIn
       args,
     });
 
-    const parser = new QuadletDryRunParser(result.stdout);
+    const parser = new QuadletDryRunParser(result);
     return parser.parse();
   }
 

--- a/packages/backend/src/services/quadlet-service.ts
+++ b/packages/backend/src/services/quadlet-service.ts
@@ -17,6 +17,7 @@ import type { SynchronisationInfo } from '/@shared/src/models/synchronisation';
 import { TelemetryEvents } from '../utils/telemetry-events';
 import { QuadletType } from '/@shared/src/utils/quadlet-type';
 import { QuadletKubeParser } from '../utils/parsers/quadlet-kube-parser';
+import { isRunError } from '../utils/run-error';
 
 export class QuadletService extends QuadletHelper implements Disposable, AsyncInit {
   #extensionsEventDisposable: Disposable | undefined;
@@ -123,7 +124,7 @@ export class QuadletService extends QuadletHelper implements Disposable, AsyncIn
       connection: provider,
       args: ['-version'],
     });
-    if (result.exitCode) throw new Error(`cannot get quadlet version (${result.exitCode}): ${result.stdout}`);
+    if (isRunError(result)) throw new Error(`cannot get quadlet version (${result.exitCode}): ${result.stderr}`);
     return result.stdout;
   }
 

--- a/packages/backend/src/utils/parsers/quadlet-dryrun-parser.ts
+++ b/packages/backend/src/utils/parsers/quadlet-dryrun-parser.ts
@@ -5,30 +5,29 @@
 import { Parser } from './iparser';
 import { QuadletUnitParser } from './quadlet-unit-parser';
 import type { Quadlet } from '../../models/quadlet';
+import type { RunResult } from '@podman-desktop/api';
+import { QuadletExtensionParser } from './quadlet-extension-parser';
+import { isAbsolute } from 'node:path/posix';
+import { randomUUID } from 'node:crypto';
 
-export class QuadletDryRunParser extends Parser<string, Quadlet[]> {
+export class QuadletDryRunParser extends Parser<RunResult & { exitCode?: number }, Quadlet[]> {
+  // match line such as 'quadlet-generator[11695]: Loading source unit file /home/user/.config/containers/systemd/nginx.image'
+  private static readonly STD_ERR_LOAD_PATTERN = /Loading source unit file (.+)/;
+
   // Stores the parsed services and their content
   private services: Record<string, Quadlet> = {};
 
-  constructor(content: string) {
+  constructor(content: RunResult) {
     super(content);
   }
 
-  /**
-   * Parses the CLI output to extract services and their content.
-   * @returns {Promise<number>} Number of services found
-   */
-  override parse(): Quadlet[] {
-    if (this.parsed) {
-      throw new Error('Content has already been parsed.');
-    }
-
+  protected parseStdout(): Quadlet[] {
     // Regular expression to match the structure of the content
     // eslint-disable-next-line sonarjs/slow-regex
     const serviceRegex = /---(.*?)---\n([\s\S]*?)(?=---|$)/g;
     let match;
 
-    while ((match = serviceRegex.exec(this.content))) {
+    while ((match = serviceRegex.exec(this.content.stdout))) {
       const serviceName = match[1].trim();
 
       // parse the quadlet unit
@@ -38,5 +37,58 @@ export class QuadletDryRunParser extends Parser<string, Quadlet[]> {
 
     this.parsed = true;
     return Object.values(this.services);
+  }
+
+  /**
+   * @param validQuadlets
+   * @protected
+   */
+  protected parseStderr(validQuadlets: Set<string>): Array<Quadlet> {
+    // split stderr by line separator
+    const lines = this.content.stderr.split('\n');
+
+    // identify all files that quadlet tried to load
+    return lines.reduce((accumulator, line) => {
+      const match = QuadletDryRunParser.STD_ERR_LOAD_PATTERN.exec(line);
+      // ignore non-matching lines
+      if (!match) return accumulator;
+
+      // ensure the path we got is valid
+      const path = match[1].trim();
+      if (!isAbsolute(path)) {
+        throw new Error(
+          `Something went wrong while parsing quadlet systemd-generator stderr, line "${line}" do not contain absolute path of quadlet file.`,
+        );
+      }
+
+      // if the quadlet we got already exist, ignore
+      if (validQuadlets.has(path)) return accumulator;
+
+      // create quadlet in error state
+      accumulator.push({
+        service: undefined, // do not have corresponding service
+        id: randomUUID(),
+        path: path,
+        content: '',
+        state: 'error',
+        type: new QuadletExtensionParser(path).parse(),
+      });
+
+      return accumulator;
+    }, [] as Array<Quadlet>);
+  }
+
+  override parse(): Quadlet[] {
+    if (this.parsed) {
+      throw new Error('Content has already been parsed.');
+    }
+
+    /**
+     * Parse the stdout for get valid quadlets
+     * @remarks valid here means that the quadlet has an associated systemd service name and is properly parsed
+     */
+    const validQuadlets = this.parseStdout();
+
+    return [...validQuadlets, ...this.parseStderr(new Set(validQuadlets.map(({ path }) => path)))];
   }
 }


### PR DESCRIPTION
## Description

To determine which Quadlet are available in a given connection, we run `/usr/libexec/podman/quadlet -user -dryrun` which output something like the following 

### `stdout`

```
---foo-image.service---
<quadlet content>
---bar-image.service---
<quadlet content>
```

### `stderr`

```
quadlet-generator[49094]: Loading source unit file /home/axel7083/.config/containers/systemd/foo.image
quadlet-generator[49094]: Loading source unit file /home/axel7083/.config/containers/systemd/bar.image
quadlet-generator[49094]: Loading source unit file /home/axel7083/.config/containers/systemd/hihih-error.image
quadlet-generator[49094]: converting "hihih-error.image": unsupported key 'Annotation' in group 'Image' in /home/axel7083/.config/containers/systemd/hihih-error.image
```

In the stdout, we always have the Quadlet corresponding systemd file for those which are converted successfully.

For those failing, they do not appear in the stdout, how to detect them? Check for lines `Loading source unit file ` in the stderr and make a diff between the one parsed from the stdout.

Why not parsing the error? Because the error is dependant on the reason it occurred, where the loading is always here no matter the problem.

## Changes

- Updating the `QuadletDryRunParser` to take a RunResult as argument where before it was only taking the stdout.

## Screenshot

Here we have two Quadlet (one generated successfully, and one with some error(s)).

![image](https://github.com/user-attachments/assets/6891d51f-b3ac-46ab-aeeb-23cbc71d76da)

## Related issue

Need the following merged before ready to review
- https://github.com/podman-desktop/extension-podman-quadlet/pull/335
- https://github.com/podman-desktop/extension-podman-quadlet/pull/333

## Testing

- [x] unit tests has been added

**Manually**

Let's generate an invalid Quadlet

1. Go to `Generate Quadlet`
2. Select anything
3. Once on the Quadlet editor space type some random stuff (adding an invalid key)
4. Go back to List
5. assert the created quadlet has orange status.
