### PR TITLE
chore(backend): cleanup `node:*` mocking

### DIFF
--- a/packages/backend/src/services/podman-service.spec.ts
+++ b/packages/backend/src/services/podman-service.spec.ts
@@ -22,16 +22,8 @@ import { mkdir, writeFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join } from 'node:path/posix';
 
-vi.mock('node:fs/promises', () => ({
-  writeFile: vi.fn(),
-  mkdir: vi.fn(),
-  readFile: vi.fn(),
-  rm: vi.fn(),
-}));
-
-vi.mock('node:os', () => ({
-  homedir: vi.fn(),
-}));
+vi.mock(import('node:fs/promises'));
+vi.mock(import('node:os'));
 
 vi.mock('@podman-desktop/api', () => ({
   Disposable: {

--- a/packages/backend/src/services/webview-service.spec.ts
+++ b/packages/backend/src/services/webview-service.spec.ts
@@ -5,13 +5,9 @@ import { expect, test, vi, beforeEach } from 'vitest';
 import type { WebviewPanel, window as windowsApi } from '@podman-desktop/api';
 import { Uri } from '@podman-desktop/api';
 import { WebviewService } from './webview-service';
-import { promises } from 'node:fs';
+import { readFile } from 'node:fs/promises';
 
-vi.mock('node:fs', () => ({
-  promises: {
-    readFile: vi.fn(),
-  },
-}));
+vi.mock(import('node:fs/promises'));
 
 vi.mock('@podman-desktop/api', () => ({
   Uri: {
@@ -47,7 +43,7 @@ beforeEach(() => {
     fsPath: '',
   } as unknown as Uri);
 
-  vi.mocked(promises.readFile).mockResolvedValue(mockedHTML);
+  vi.mocked(readFile).mockResolvedValue(mockedHTML);
 });
 
 test('non-init service should throw an error trying to access webview', async () => {

--- a/packages/backend/src/services/webview-service.ts
+++ b/packages/backend/src/services/webview-service.ts
@@ -3,7 +3,7 @@
  */
 import { Uri } from '@podman-desktop/api';
 import type { Disposable, WebviewOptions, WebviewPanel, window } from '@podman-desktop/api';
-import { promises } from 'node:fs';
+import { readFile } from 'node:fs/promises';
 import type { AsyncInit } from '../utils/async-init';
 
 interface Dependencies {
@@ -32,7 +32,7 @@ export class WebviewService implements Disposable, AsyncInit {
     const indexHtmlUri = Uri.joinPath(this.#mediaPath, 'index.html');
     const indexHtmlPath = indexHtmlUri.fsPath;
 
-    let indexHtml = await promises.readFile(indexHtmlPath, 'utf8');
+    let indexHtml = await readFile(indexHtmlPath, 'utf8');
 
     // replace links with webView Uri links
     // in the content <script type="module" crossorigin src="./index-RKnfBG18.js"></script> replace src with webview.asWebviewUri


### PR DESCRIPTION
## Description

We can simplify the mocking when they only mock `functions` and `classes` to simply the module, vitest will mock all properly.

## Testing

- [x] Unit tests ensure no regression