### PR TITLE
chore(deps): bump @podman-desktop/* to 1.17

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -63,8 +63,8 @@
     ]
   },
   "devDependencies": {
-    "@podman-desktop/api": "^1.16.2",
-    "@podman-desktop/podman-extension-api": "^1.16.0",
+    "@podman-desktop/api": "^1.17.0",
+    "@podman-desktop/podman-extension-api": "^1.17.0",
     "@types/node": "^20",
     "@types/tar-fs": "^2.0.4",
     "@types/unzipper": "^0.10.10",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -26,7 +26,7 @@
     "@fortawesome/free-brands-svg-icons": "^6.7.2",
     "@fortawesome/free-regular-svg-icons": "^6.7.2",
     "@fortawesome/free-solid-svg-icons": "^6.7.2",
-    "@podman-desktop/ui-svelte": "^1.16.0",
+    "@podman-desktop/ui-svelte": "^1.17.0",
     "@sveltejs/vite-plugin-svelte": "5.0.3",
     "@tailwindcss/typography": "^0.5.16",
     "@tailwindcss/vite": "^4.0.9",

--- a/packages/podlet-js/package.json
+++ b/packages/podlet-js/package.json
@@ -17,7 +17,7 @@
     "vite": "^6.2.0",
     "vitest": "^2.1.6",
     "vite-plugin-dts": "^4.5.3",
-    "@podman-desktop/api": "^1.16.2"
+    "@podman-desktop/api": "^1.17.0"
   },
   "dependencies": {
     "js-ini": "^1.6.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,11 +116,11 @@ importers:
         version: 0.11.6
     devDependencies:
       '@podman-desktop/api':
-        specifier: ^1.16.2
-        version: 1.16.2
+        specifier: ^1.17.0
+        version: 1.17.0
       '@podman-desktop/podman-extension-api':
-        specifier: ^1.16.0
-        version: 1.16.0
+        specifier: ^1.17.0
+        version: 1.17.0
       '@types/js-yaml':
         specifier: ^4.0.9
         version: 4.0.9
@@ -183,8 +183,8 @@ importers:
         specifier: ^6.7.2
         version: 6.7.2
       '@podman-desktop/ui-svelte':
-        specifier: ^1.16.0
-        version: 1.16.0(svelte-fa@4.0.3(svelte@5.20.5))(svelte@5.20.5)
+        specifier: ^1.17.0
+        version: 1.17.0(svelte-fa@4.0.3(svelte@5.20.5))(svelte@5.20.5)
       '@sveltejs/vite-plugin-svelte':
         specifier: 5.0.3
         version: 5.0.3(svelte@5.20.5)(vite@6.2.0(@types/node@20.17.22)(jiti@2.4.2)(lightningcss@1.29.1)(yaml@2.6.1))
@@ -268,8 +268,8 @@ importers:
         version: 1.6.0
     devDependencies:
       '@podman-desktop/api':
-        specifier: ^1.16.2
-        version: 1.16.2
+        specifier: ^1.17.0
+        version: 1.17.0
       typescript:
         specifier: 5.7.3
         version: 5.7.3
@@ -286,8 +286,8 @@ importers:
   tests/playwright:
     devDependencies:
       '@playwright/test':
-        specifier: ^1.49.1
-        version: 1.49.1
+        specifier: ^1.50.1
+        version: 1.50.1
       '@podman-desktop/tests-playwright':
         specifier: 1.17.0
         version: 1.17.0
@@ -930,25 +930,22 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
-  '@playwright/test@1.49.1':
-    resolution: {integrity: sha512-Ky+BVzPz8pL6PQxHqNRW1k3mIyv933LML7HktS8uik0bUXNCdPhoS/kLihiO1tMf/egaJb4IutXd7UywvXEW+g==}
+  '@playwright/test@1.50.1':
+    resolution: {integrity: sha512-Jii3aBg+CEDpgnuDxEp/h7BimHcUTDlpEtce89xEumlJ5ef2hqepZ+PWp1DDpYC/VO9fmWVI1IlEaoI5fK9FXQ==}
     engines: {node: '>=18'}
     hasBin: true
 
-  '@podman-desktop/api@1.16.0':
-    resolution: {integrity: sha512-ZgSN3oJkwzoz2oMBO77EA+7rugt7R7kL6JmVtq5siXrRqj2Nn9tj0KYMv/jzz9KhlaHI2/ELN0qLWLNFuvxu0Q==}
+  '@podman-desktop/api@1.17.0':
+    resolution: {integrity: sha512-i+CxiZpEnMHpNrGdLLkA4zbRpYjm6P4iJE1nDTehyGBnBum6nQuUDqIplW+LQJsO8vK/z4Tc5I8lI2ObMWnaUg==}
 
-  '@podman-desktop/api@1.16.2':
-    resolution: {integrity: sha512-DwcMvKFSBrmlPuXaFssHhlhBruFfVH5261R9TxyjeLWjEUwefggK72TrP5ndZPl3N25il202fQazkecRE94Qhw==}
-
-  '@podman-desktop/podman-extension-api@1.16.0':
-    resolution: {integrity: sha512-4WPJesH/ySVmaniWgQLAe8YHcwtdTZ7vT0GITAcZozBrvOWLPQBbef5+GcMN7RSHUELF+g/aSwO9/cdKpGLY2A==}
+  '@podman-desktop/podman-extension-api@1.17.0':
+    resolution: {integrity: sha512-UR/6OHrzY1qu/OoEOIec7DGXx4xxE8rGdrFWj2oEBfVyGWhOfw+7Z4ZeW96AKVkydfPPAXCqivEqdsaq84DfbA==}
 
   '@podman-desktop/tests-playwright@1.17.0':
     resolution: {integrity: sha512-w0rwGBg3Gi0AIwmkGmAxrA4+oC07NPxxpecPume1LqBX8k0CyVRVV9c2dQW+zg4mNKZFSDo5MVgI0ghF+qptNA==}
 
-  '@podman-desktop/ui-svelte@1.16.0':
-    resolution: {integrity: sha512-sNe4Gk/+3bQEhtrTSkN5zRSB/S2p0DGEOpHCeugfB6vz4xy1MLrG6xGsqDAV8CDSiT92tn0oTyyI6zposyKu5g==}
+  '@podman-desktop/ui-svelte@1.17.0':
+    resolution: {integrity: sha512-run/nbogkAboohrG6MGtj/a4RcHC4tMBRG9ohwtu0CV3INpnuJ61EQ4g/yl/2N17crp0+DZ4/TSEymNYshub4g==}
     peerDependencies:
       svelte: ^4.0.0 || ^5.0.0
       svelte-fa: ^4.0.0
@@ -3260,13 +3257,13 @@ packages:
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
-  playwright-core@1.49.1:
-    resolution: {integrity: sha512-BzmpVcs4kE2CH15rWfzpjzVGhWERJfmnXmniSyKeRZUs9Ws65m+RGIi7mjJK/euCegfn3i7jvqWeWyHe9y3Vgg==}
+  playwright-core@1.50.1:
+    resolution: {integrity: sha512-ra9fsNWayuYumt+NiM069M6OkcRb1FZSK8bgi66AtpFoWkg2+y0bJSNmkFrWhMbEBbVKC/EruAHH3g0zmtwGmQ==}
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.49.1:
-    resolution: {integrity: sha512-VYL8zLoNTBxVOrJBbDuRgDWa3i+mfQgDTrL8Ah9QXZ7ax4Dsj0MSq5bYgytRnDVVe+njoKnfsYkH3HzqVj5UZA==}
+  playwright@1.50.1:
+    resolution: {integrity: sha512-G8rwsOQJ63XG6BbKj2w5rHeavFjy5zynBA9zsJMMtBoe/Uf757oG12NXz6e6OirF7RCrTVAKFXbLmn1RbL7Qaw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -4849,21 +4846,19 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  '@playwright/test@1.49.1':
+  '@playwright/test@1.50.1':
     dependencies:
-      playwright: 1.49.1
+      playwright: 1.50.1
 
-  '@podman-desktop/api@1.16.0': {}
+  '@podman-desktop/api@1.17.0': {}
 
-  '@podman-desktop/api@1.16.2': {}
-
-  '@podman-desktop/podman-extension-api@1.16.0':
+  '@podman-desktop/podman-extension-api@1.17.0':
     dependencies:
-      '@podman-desktop/api': 1.16.0
+      '@podman-desktop/api': 1.17.0
 
   '@podman-desktop/tests-playwright@1.17.0': {}
 
-  '@podman-desktop/ui-svelte@1.16.0(svelte-fa@4.0.3(svelte@5.20.5))(svelte@5.20.5)':
+  '@podman-desktop/ui-svelte@1.17.0(svelte-fa@4.0.3(svelte@5.20.5))(svelte@5.20.5)':
     dependencies:
       '@fortawesome/fontawesome-free': 6.7.2
       '@fortawesome/free-brands-svg-icons': 6.7.2
@@ -7484,11 +7479,11 @@ snapshots:
       mlly: 1.7.4
       pathe: 2.0.3
 
-  playwright-core@1.49.1: {}
+  playwright-core@1.50.1: {}
 
-  playwright@1.49.1:
+  playwright@1.50.1:
     dependencies:
-      playwright-core: 1.49.1
+      playwright-core: 1.50.1
     optionalDependencies:
       fsevents: 2.3.2
 

--- a/tests/playwright/package.json
+++ b/tests/playwright/package.json
@@ -10,7 +10,7 @@
   "publisher": "podman-desktop",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@playwright/test": "^1.49.1",
+    "@playwright/test": "^1.50.1",
     "@podman-desktop/tests-playwright": "1.17.0",
     "@types/node": "^20",
     "electron": "^34.3.0",


### PR DESCRIPTION
## Description

Bumping podman-desktop libs to 1.17

## Notes

- The version of playwright use **must** match the one shipped with `podman-desktop`, so bumping `@playwright/test`

## Related issues

Fixes https://github.com/podman-desktop/extension-podman-quadlet/issues/357

## Testing

- [x] pipeline should be :heavy_check_mark: 
