### PR TITLE
feat: makes quadlet content optional

### DIFF
--- a/packages/backend/src/models/quadlet.ts
+++ b/packages/backend/src/models/quadlet.ts
@@ -22,8 +22,9 @@ export interface Quadlet {
   path: string;
   /**
    * raw content (generate) of the service file
+   * @remarks this may be undefined if no associated systemd could be found
    */
-  content: string;
+  content?: string;
   /**
    * State of the quadlet
    */

--- a/packages/backend/src/services/quadlet-service.spec.ts
+++ b/packages/backend/src/services/quadlet-service.spec.ts
@@ -175,7 +175,7 @@ describe('QuadletService#collectPodmanQuadlet', () => {
       args: ['-dryrun', '-user'],
     });
 
-    expect(quadlet.all()).toHaveLength(2);
+    expect(quadlet.all()).toHaveLength(3);
   });
 });
 
@@ -341,7 +341,7 @@ describe('QuadletService#refreshQuadletsStatuses', () => {
     // should have been called only with the quadlet with a corresponding service
     expect(SYSTEMD_SERVICE_MOCK.getActiveStatus).toHaveBeenCalledWith(
       expect.objectContaining({
-        services: [QUADLET_MOCK.service],
+        services: [QUADLET_MOCK.service, KUBE_QUADLET_MOCK.service],
       }),
     );
   });

--- a/packages/backend/src/services/quadlet-service.ts
+++ b/packages/backend/src/services/quadlet-service.ts
@@ -517,6 +517,9 @@ export class QuadletService extends QuadletHelper implements Disposable, AsyncIn
     if (quadlet.type !== QuadletType.KUBE)
       throw new Error(`cannot get kube yaml of non-kube quadlet: quadlet ${quadlet.id} type is ${quadlet.type}`);
 
+    if (!quadlet.content || !quadlet.service)
+      throw new Error('cannot get kube yaml: quadlet without associated systemd service cannot be parsed.');
+
     // extract the yaml file from
     const { yaml } = new QuadletKubeParser(quadlet.content).parse();
 

--- a/packages/backend/src/utils/parsers/quadlet-dryrun-parser.spec.ts
+++ b/packages/backend/src/utils/parsers/quadlet-dryrun-parser.spec.ts
@@ -106,9 +106,11 @@ test('should parse stderr properly and properly set state', async () => {
 
   expect(container.path).toBe('/home/user/.config/containers/systemd/nginx.container');
   expect(container.state).toBe('error');
+  expect(container.content).toBeUndefined();
 
   expect(image.path).toBe('/home/user/.config/containers/systemd/nginx.image');
   expect(image.state).toBe('error');
+  expect(image.content).toBeUndefined();
 });
 
 test('overlapping stderr should be overwritten by stdout', async () => {

--- a/packages/backend/src/utils/parsers/quadlet-dryrun-parser.ts
+++ b/packages/backend/src/utils/parsers/quadlet-dryrun-parser.ts
@@ -69,7 +69,6 @@ export class QuadletDryRunParser extends Parser<RunResult & { exitCode?: number 
         service: undefined, // do not have corresponding service
         id: randomUUID(),
         path: path,
-        content: '',
         state: 'error',
         type: new QuadletExtensionParser(path).parse(),
       });

--- a/packages/frontend/src/pages/QuadletDetails.spec.ts
+++ b/packages/frontend/src/pages/QuadletDetails.spec.ts
@@ -80,7 +80,6 @@ const INVALID_IMAGE_QUADLET_MOCK: QuadletInfo = {
   // either WSL either QEMU
   connection: WSL_PROVIDER_DETAILED_INFO,
   id: `foo-invalid-image-id`,
-  content: 'dummy-content',
   state: 'active',
   path: `bar/foo.image`,
   type: QuadletType.IMAGE,
@@ -120,6 +119,22 @@ test('container quadlet should have generated and source tab', async () => {
   expect(sourceTab).toBeInTheDocument();
   const kubeTab = queryByText('kube yaml');
   expect(kubeTab).toBeNull();
+});
+
+test('invalid quadlet should not have generated tab', async () => {
+  const { getByText, queryByText } = render(QuadletDetails, {
+    connection: WSL_PROVIDER_DETAILED_INFO.name,
+    providerId: WSL_PROVIDER_DETAILED_INFO.providerId,
+    id: INVALID_IMAGE_QUADLET_MOCK.id,
+  });
+
+  // generate should not be in the visible
+  const generateTab = queryByText('Systemd Service');
+  expect(generateTab).toBeNull();
+
+  // source should be visible
+  const sourceTab = getByText('Source');
+  expect(sourceTab).toBeInTheDocument();
 });
 
 test('kube quadlet should have kube yaml tab', async () => {

--- a/packages/frontend/src/pages/QuadletDetails.svelte
+++ b/packages/frontend/src/pages/QuadletDetails.svelte
@@ -145,10 +145,12 @@ function onchange(content: string): void {
         url="/quadlets/{providerId}/{connection}/{id}"
         selected={$router.path === `/quadlets/${providerId}/${connection}/${id}`} />
       <!-- systemd-service tab -->
-      <Tab
-        title="Systemd Service"
-        url="/quadlets/{providerId}/{connection}/{id}/systemd-service"
-        selected={$router.path === `/quadlets/${providerId}/${connection}/${id}/systemd-service`} />
+      {#if quadlet.content}
+        <Tab
+          title="Systemd Service"
+          url="/quadlets/{providerId}/{connection}/{id}/systemd-service"
+          selected={$router.path === `/quadlets/${providerId}/${connection}/${id}/systemd-service`} />
+      {/if}
       <!-- kube yaml tab -->
       {#if quadlet.type === QuadletType.KUBE}
         <Tab
@@ -201,7 +203,9 @@ function onchange(content: string): void {
           </div>
           <!-- monaco editor is multiplying the build time by too much -->
           <!-- <MonacoEditor readOnly content={quadlet.content} language="ini" /> -->
-          <MonacoEditor class="h-full" readOnly content={quadlet.content} language="ini" />
+          {#if quadlet.content}
+            <MonacoEditor class="h-full" readOnly content={quadlet.content} language="ini" />
+          {/if}
         </Route>
 
         <Route path="/yaml">

--- a/packages/shared/src/models/quadlet-info.ts
+++ b/packages/shared/src/models/quadlet-info.ts
@@ -24,8 +24,9 @@ export interface QuadletInfo {
   path: string;
   /**
    * raw content (generate) of the service file
+   * @remarks this may be undefined if no associated systemd could be found
    */
-  content: string;
+  content?: string;
   /**
    * State of the quadlet
    */


### PR DESCRIPTION
## Description

When a Quadlet is in an error state (invalid YAML, invalid property, etc.) it does not have an associated systemd service.

The `Quadlet#content` property corresponds to the systemd generate content, but when the quadlet is in an error state this is undefined.

To better reflect the reality, making the field optional, and nicely handle it.

## Screenshots

**Quadlet in Error state**

![image](https://github.com/user-attachments/assets/3db76a15-f4d3-474c-9146-7d26babe41e1)

**Valid Quadlet**

![image](https://github.com/user-attachments/assets/87e61134-209f-4c51-b8a8-c6e9137c94f6)


## Related issues

Fixes https://github.com/podman-desktop/extension-podman-quadlet/issues/343

## Testing

- [x] unit tests has been provided
