### PR TITLE
feat(podlet-js): adding basic compose logic

### DIFF
--- a/packages/podlet-js/package.json
+++ b/packages/podlet-js/package.json
@@ -17,10 +17,13 @@
     "vite": "^6.2.2",
     "vitest": "^2.1.6",
     "vite-plugin-dts": "^4.5.3",
+    "@types/js-yaml": "^4.0.9",
     "@podman-desktop/api": "^1.17.0"
   },
   "dependencies": {
-    "js-ini": "^1.6.0"
+    "js-ini": "^1.6.0",
+    "js-yaml": "^4.1.0",
+    "compose-spec-ts": "^0.3.2"
   },
   "files": [
     "dist"

--- a/packages/podlet-js/src/compose/compose.spec.ts
+++ b/packages/podlet-js/src/compose/compose.spec.ts
@@ -1,0 +1,44 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import { test, expect, describe } from 'vitest';
+import { readdir, readFile, access } from 'node:fs/promises';
+import { join } from 'node:path';
+import { Compose } from './compose';
+
+const assetsDir = join(__dirname, './tests');
+
+describe('compose', async () => {
+  const folders = await readdir(assetsDir);
+
+  test.each(folders)('should generate correct output for %s', async folder => {
+    const folderPath = join(assetsDir, folder);
+    const composeYaml = join(folderPath, 'compose.yaml');
+    const expectYaml = join(folderPath, 'expect.yaml');
+
+    await Promise.all(
+      [composeYaml, expectYaml].map(async file => {
+        await access(file);
+      }),
+    );
+
+    const [composeRaw, expectRaw] = await Promise.all([readFile(composeYaml, 'utf-8'), readFile(expectYaml, 'utf-8')]);
+
+    const compose = Compose.fromString(composeRaw);
+    expect(compose.toKubePlay()).toStrictEqual(expectRaw);
+  });
+});

--- a/packages/podlet-js/src/compose/compose.ts
+++ b/packages/podlet-js/src/compose/compose.ts
@@ -1,0 +1,102 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import type { ComposeSpecification, DefinitionsService, PropertiesServices } from 'compose-spec-ts';
+import { load, dump } from 'js-yaml';
+import type { PodContainer, PodContainerPort, PodmanPod } from './models/podman-pod';
+
+export const COMPOSE_SPECIFICATION_SUPPORTED: Set<keyof ComposeSpecification> = new Set([
+  'services',
+  'name',
+  'version',
+]);
+
+export const SERVICE_SUPPORTED: Set<keyof DefinitionsService> = new Set(['image', 'ports']);
+
+export class Compose {
+  #spec: ComposeSpecification;
+
+  protected constructor(spec: ComposeSpecification) {
+    this.#spec = spec;
+  }
+
+  public static fromString(raw: string): Compose {
+    return new Compose(load(raw) as ComposeSpecification);
+  }
+
+  public getServices(): PropertiesServices {
+    return this.#spec.services ?? {};
+  }
+
+  // todo: move to dedicated file
+  private toPodContainer([name, service]: [string, DefinitionsService]): PodContainer {
+    Object.keys(service).forEach((key: string) => {
+      if (!SERVICE_SUPPORTED.has(key)) throw new Error(`unsupported option ${key} for service ${name}`);
+    });
+
+    if (!service.image) throw new Error('missing image');
+
+    const ports: Array<PodContainerPort> | undefined = service.ports?.map(port => {
+      if (typeof port === 'number') {
+        return {
+          containerPort: port,
+          hostPort: port,
+        };
+      } else if (typeof port === 'string') {
+        const [containerPort, hostPort] = port.split(':');
+        return {
+          containerPort: Number(containerPort),
+          hostPort: Number(hostPort),
+        };
+      } else {
+        return {
+          containerPort: Number(port.target),
+          hostPort: Number(port.published),
+        };
+      }
+    });
+
+    return {
+      image: service.image,
+      name: name,
+      ports,
+    };
+  }
+
+  toKubePlay(): string {
+    // check for unsupported option at root level
+    Object.keys(this.#spec).forEach((key: string) => {
+      if (!COMPOSE_SPECIFICATION_SUPPORTED.has(key)) throw new Error(`unsupported option ${key}`);
+    });
+
+    const services: PropertiesServices = this.getServices();
+    const containers: Array<PodContainer> = Object.entries(services).map(this.toPodContainer);
+
+    const pod: PodmanPod = {
+      apiVersion: 'v1',
+      kind: 'Pod',
+      metadata: {
+        name: this.#spec.name ?? 'compose-podified',
+      },
+      spec: {
+        containers: containers,
+      },
+    };
+
+    return dump(pod);
+  }
+}

--- a/packages/podlet-js/src/compose/models/podman-pod.ts
+++ b/packages/podlet-js/src/compose/models/podman-pod.ts
@@ -1,0 +1,39 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+export interface PodContainerPort {
+  containerPort: number;
+  hostPort: number;
+}
+
+export interface PodContainer {
+  image: string;
+  name: string;
+  ports?: Array<PodContainerPort>;
+}
+
+export interface PodmanPod {
+  apiVersion: 'v1';
+  kind: 'Pod';
+  metadata: {
+    name: string;
+  };
+  spec: {
+    containers: Array<PodContainer>;
+  };
+}

--- a/packages/podlet-js/src/compose/tests/redis/compose.yaml
+++ b/packages/podlet-js/src/compose/tests/redis/compose.yaml
@@ -1,0 +1,5 @@
+services:
+  redis:
+    image: redislabs/redismod
+    ports:
+      - '6379:6379'

--- a/packages/podlet-js/src/compose/tests/redis/expect.yaml
+++ b/packages/podlet-js/src/compose/tests/redis/expect.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: compose-podified
+spec:
+  containers:
+    - image: redislabs/redismod
+      name: redis
+      ports:
+        - containerPort: 6379
+          hostPort: 6379

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,7 +35,7 @@ importers:
         version: 9.22.0(jiti@2.4.2)
       eslint-import-resolver-custom-alias:
         specifier: ^1.3.2
-        version: 1.3.2(eslint-plugin-import@2.31.0)
+        version: 1.3.2(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.26.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2))(eslint-import-resolver-typescript@4.2.2)(eslint@9.22.0(jiti@2.4.2)))
       eslint-import-resolver-typescript:
         specifier: ^4.2.2
         version: 4.2.2(eslint-plugin-import@2.31.0)(eslint@9.22.0(jiti@2.4.2))(is-bun-module@1.3.0)
@@ -263,13 +263,22 @@ importers:
 
   packages/podlet-js:
     dependencies:
+      compose-spec-ts:
+        specifier: ^0.3.2
+        version: 0.3.2
       js-ini:
         specifier: ^1.6.0
         version: 1.6.0
+      js-yaml:
+        specifier: ^4.1.0
+        version: 4.1.0
     devDependencies:
       '@podman-desktop/api':
         specifier: ^1.17.0
         version: 1.17.0
+      '@types/js-yaml':
+        specifier: ^4.0.9
+        version: 4.0.9
       typescript:
         specifier: 5.8.2
         version: 5.8.2
@@ -1875,6 +1884,9 @@ packages:
 
   compare-versions@6.1.1:
     resolution: {integrity: sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==}
+
+  compose-spec-ts@0.3.2:
+    resolution: {integrity: sha512-+SyLdwbWOhK+imI0S6fAShB8qRdWInBMHe20rtq1bKQwaJnkQDhLAu23DEFma5BmrssNpAGQ/EtsxzWnGYqYOw==}
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
@@ -5953,6 +5965,8 @@ snapshots:
 
   compare-versions@6.1.1: {}
 
+  compose-spec-ts@0.3.2: {}
+
   concat-map@0.0.1: {}
 
   concurrently@9.1.2:
@@ -6358,7 +6372,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-custom-alias@1.3.2(eslint-plugin-import@2.31.0):
+  eslint-import-resolver-custom-alias@1.3.2(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.26.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2))(eslint-import-resolver-typescript@4.2.2)(eslint@9.22.0(jiti@2.4.2))):
     dependencies:
       eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.26.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2))(eslint-import-resolver-typescript@4.2.2)(eslint@9.22.0(jiti@2.4.2))
       glob-parent: 6.0.2
@@ -6386,7 +6400,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.26.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.2.2)(eslint@9.22.0(jiti@2.4.2)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.26.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.2.2(eslint-plugin-import@2.31.0)(eslint@9.22.0(jiti@2.4.2))(is-bun-module@1.3.0))(eslint@9.22.0(jiti@2.4.2)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -6421,7 +6435,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.22.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.26.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.2.2)(eslint@9.22.0(jiti@2.4.2))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.26.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.2.2(eslint-plugin-import@2.31.0)(eslint@9.22.0(jiti@2.4.2))(is-bun-module@1.3.0))(eslint@9.22.0(jiti@2.4.2))
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3


### PR DESCRIPTION
## Description

We rely on the Podlet tool to generate the following
- Container Quadlet (alternative implemented through https://github.com/podman-desktop/extension-podman-quadlet/pull/348)
- Image Quadlet (alternative implemented through https://github.com/podman-desktop/extension-podman-quadlet/pull/332)

The last element we need an alternative to remove podlet is the compose generation: this PR introduce a very basic compose generator.

## Related issues

Required for https://github.com/podman-desktop/extension-podman-quadlet/issues/298

## Testing

In the same way testing has been implemented for containers and image generator.

In the `packages/podlet-js/src/compose/tests` there are several folders; the structure of each folder in it is the following

```
.
└── tests/
    └── <test-case>/
        ├── expect.yaml
        ├── compose.yaml
```

The file `packages/podlet-js/src/compose/composespec.ts` will read the files and generate a kube quadlet, and ensure it match the `expect.ini`.
