### PR TITLE
fix(podlet-js): adding missing export

### DIFF
--- a/packages/podlet-js/src/index.ts
+++ b/packages/podlet-js/src/index.ts
@@ -17,5 +17,6 @@
  ***********************************************************************/
 import { ContainerGenerator } from './containers/container-generator';
 import { ImageGenerator } from './images/image-generator';
+import { Compose } from './compose/compose';
 
-export { ImageGenerator, ContainerGenerator };
+export { ImageGenerator, Compose, ContainerGenerator };


### PR DESCRIPTION
## Description

Following https://github.com/podman-desktop/extension-podman-quadlet/pull/406, adding missing export for the `Compose` class.
