### PR TITLE
feat(backend): create `PodletJsService`

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -76,9 +76,6 @@ jobs:
           node-version: 22
           cache: 'pnpm'
 
-      - name: Execute Build
-        run: pnpm build
-
       - name: Execute pnpm
         run: pnpm install
 

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -76,6 +76,9 @@ jobs:
           node-version: 22
           cache: 'pnpm'
 
+      - name: Execute Build
+        run: pnpm build
+
       - name: Execute pnpm
         run: pnpm install
 

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -82,6 +82,7 @@
     "semver": "^7.7.1",
     "tar-fs": "^3.0.8",
     "unzipper": "^0.11.6",
-    "js-yaml": "^4.1.0"
+    "js-yaml": "^4.1.0",
+    "podlet-js": "workspace:^"
   }
 }

--- a/packages/backend/src/services/container-service.spec.ts
+++ b/packages/backend/src/services/container-service.spec.ts
@@ -27,6 +27,7 @@ const PROVIDER_SERVICE_MOCK: ProviderService = {
 
 const CONTAINER_ENGINE_MOCK: typeof containerEngine = {
   listInfos: vi.fn(),
+  inspectContainer: vi.fn(),
 } as unknown as typeof containerEngine;
 
 const WSL_RUNNING_PROVIDER_CONNECTION_MOCK: ProviderContainerConnection = {
@@ -89,4 +90,14 @@ test('getRunningProviderContainerConnectionByEngineId should throw an error if n
     await container.getRunningProviderContainerConnectionByEngineId('dummy engine id');
   }).rejects.toThrowError('connection not found');
   expect(CONTAINER_ENGINE_MOCK.listInfos).not.toHaveBeenCalled();
+});
+
+test('ContainerService#inspectContainer should use api inspectContainer', async () => {
+  const container = new ContainerService({
+    providers: PROVIDER_SERVICE_MOCK,
+    containers: CONTAINER_ENGINE_MOCK,
+  });
+
+  await container.inspectContainer('dummy-engine-id', 'dummy-container-id');
+  expect(CONTAINER_ENGINE_MOCK.inspectContainer).toHaveBeenCalledWith('dummy-engine-id', 'dummy-container-id');
 });

--- a/packages/backend/src/services/container-service.ts
+++ b/packages/backend/src/services/container-service.ts
@@ -1,7 +1,7 @@
 /**
  * @author axel7083
  */
-import type { Disposable, ContainerInfo, ProviderContainerConnection } from '@podman-desktop/api';
+import type { Disposable, ContainerInfo, ProviderContainerConnection, ContainerInspectInfo } from '@podman-desktop/api';
 import type { AsyncInit } from '../utils/async-init';
 import type { SimpleContainerInfo } from '/@shared/src/models/simple-container-info';
 import type { ProviderService } from './provider-service';
@@ -54,6 +54,17 @@ export class ContainerService extends EngineHelper<Dependencies> implements Disp
       if (infos[0].engineId === engineId) return provider;
     }
     throw new Error('connection not found');
+  }
+
+  public async getEngineId(connection: ProviderContainerConnectionIdentifierInfo): Promise<string> {
+    const provider = this.dependencies.providers.getProviderContainerConnection(connection);
+
+    const info = await this.getEngineInfo(provider.connection);
+    return info.engineId;
+  }
+
+  public inspectContainer(engineId: string, containerId: string): Promise<ContainerInspectInfo> {
+    return this.dependencies.containers.inspectContainer(engineId, containerId);
   }
 
   protected toSimpleContainerInfo(

--- a/packages/backend/src/services/image-service.spec.ts
+++ b/packages/backend/src/services/image-service.spec.ts
@@ -1,0 +1,48 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { beforeEach, vi, test, expect } from 'vitest';
+import { ImageService } from './image-service';
+import type { ProviderService } from './provider-service';
+import type { containerEngine } from '@podman-desktop/api';
+
+const PROVIDER_SERVICE_MOCK: ProviderService = {
+  getContainerConnections: vi.fn(),
+} as unknown as ProviderService;
+
+const CONTAINER_ENGINE_MOCK: typeof containerEngine = {
+  getImageInspect: vi.fn(),
+} as unknown as typeof containerEngine;
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+function getImageService(): ImageService {
+  return new ImageService({
+    providers: PROVIDER_SERVICE_MOCK,
+    containers: CONTAINER_ENGINE_MOCK,
+  });
+}
+
+test('ImageService#inspectImage should use container engine getImageInspect', async () => {
+  const image = getImageService();
+  await image.inspectImage('dummy-engine-id', 'dummy-image-id');
+
+  expect(CONTAINER_ENGINE_MOCK.getImageInspect).toHaveBeenCalledWith('dummy-engine-id', 'dummy-image-id');
+});

--- a/packages/backend/src/services/image-service.ts
+++ b/packages/backend/src/services/image-service.ts
@@ -1,7 +1,7 @@
 /**
  * @author axel7083
  */
-import type { Disposable, ImageInfo } from '@podman-desktop/api';
+import type { Disposable, ImageInfo, ImageInspectInfo } from '@podman-desktop/api';
 import type { AsyncInit } from '../utils/async-init';
 import type { ProviderService } from './provider-service';
 import type { EngineHelperDependencies } from './engine-helper';
@@ -29,6 +29,10 @@ export class ImageService extends EngineHelper<Dependencies> implements Disposab
     });
 
     return images.map(image => this.toSimpleImageInfo(image, providerConnection));
+  }
+
+  public inspectImage(engineId: string, imageId: string): Promise<ImageInspectInfo> {
+    return this.dependencies.containers.getImageInspect(engineId, imageId);
   }
 
   protected toSimpleImageInfo(

--- a/packages/backend/src/services/podlet-js-service.spec.ts
+++ b/packages/backend/src/services/podlet-js-service.spec.ts
@@ -1,0 +1,191 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import type { ContainerService } from './container-service';
+import type { ImageService } from './image-service';
+import { PodletJsService } from './podlet-js-service';
+import type { ProviderContainerConnectionIdentifierInfo } from '/@shared/src/models/provider-container-connection-identifier-info';
+import { QuadletType } from '/@shared/src/utils/quadlet-type';
+import type { ContainerInspectInfo, ImageInspectInfo } from '@podman-desktop/api';
+import { Compose, ContainerGenerator, ImageGenerator } from 'podlet-js';
+import { readFile } from 'node:fs/promises';
+
+/**
+ *  mock the podlet-js library
+ *  @remarks here we do not test the podlet-js library, we test the service
+ */
+vi.mock(import('podlet-js'));
+// mock filesystem
+vi.mock(import('node:fs/promises'));
+
+const CONTAINER_SERVICE_MOCK: ContainerService = {
+  inspectContainer: vi.fn(),
+  getEngineId: vi.fn(),
+} as unknown as ContainerService;
+
+const IMAGE_SERVICE_MOCK: ImageService = {
+  inspectImage: vi.fn(),
+} as unknown as ImageService;
+
+const CONTAINER_CONNECTION_IDENTIFIER: ProviderContainerConnectionIdentifierInfo = {
+  providerId: 'podman',
+  name: 'Podman',
+};
+
+const ENGINE_ID_MOCK: string = 'dummy-engine-id';
+
+const IMAGE_INSPECT_MOCK: ImageInspectInfo = {
+  engineId: ENGINE_ID_MOCK,
+  Id: 'image-id',
+} as unknown as ImageInspectInfo;
+
+const CONTAINER_INSPECT_MOCK: ContainerInspectInfo = {
+  engineId: ENGINE_ID_MOCK,
+  Image: 'dummy-image',
+  Id: 'container-id',
+} as unknown as ContainerInspectInfo;
+
+const CONTAINER_GENERATE_OUTPUT: string = 'container-quadlet-content';
+const IMAGE_GENERATE_OUTPUT: string = 'image-quadlet-content';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+
+  // mock container service
+  vi.mocked(CONTAINER_SERVICE_MOCK.getEngineId).mockResolvedValue(ENGINE_ID_MOCK);
+  vi.mocked(CONTAINER_SERVICE_MOCK.inspectContainer).mockResolvedValue(CONTAINER_INSPECT_MOCK);
+  // mock image service
+  vi.mocked(IMAGE_SERVICE_MOCK.inspectImage).mockResolvedValue(IMAGE_INSPECT_MOCK);
+
+  vi.mocked(ContainerGenerator.prototype.generate).mockReturnValue(CONTAINER_GENERATE_OUTPUT);
+  vi.mocked(ImageGenerator.prototype.generate).mockReturnValue(IMAGE_GENERATE_OUTPUT);
+});
+
+function getService(): PodletJsService {
+  return new PodletJsService({
+    containers: CONTAINER_SERVICE_MOCK,
+    images: IMAGE_SERVICE_MOCK,
+  });
+}
+
+describe('container quadlets', () => {
+  test('should use the container and image service to inspect resources', async () => {
+    const podletJs = getService();
+
+    // generate container quadlet
+    const result = await podletJs.generate({
+      connection: CONTAINER_CONNECTION_IDENTIFIER,
+      type: QuadletType.CONTAINER,
+      resourceId: CONTAINER_INSPECT_MOCK.Id,
+    });
+
+    // Should get the corresponding engine id
+    expect(CONTAINER_SERVICE_MOCK.getEngineId).toHaveBeenCalledOnce();
+    expect(CONTAINER_SERVICE_MOCK.getEngineId).toHaveBeenCalledWith(CONTAINER_CONNECTION_IDENTIFIER);
+
+    // should get the container inspect info
+    expect(CONTAINER_SERVICE_MOCK.inspectContainer).toHaveBeenCalledOnce();
+    expect(CONTAINER_SERVICE_MOCK.inspectContainer).toHaveBeenCalledWith(ENGINE_ID_MOCK, CONTAINER_INSPECT_MOCK.Id);
+
+    // should get the image inspect info
+    expect(IMAGE_SERVICE_MOCK.inspectImage).toHaveBeenCalledOnce();
+    expect(IMAGE_SERVICE_MOCK.inspectImage).toHaveBeenCalledWith(ENGINE_ID_MOCK, CONTAINER_INSPECT_MOCK.Image);
+
+    // should properly call the podlet-js container generator
+    expect(ContainerGenerator).toHaveBeenCalledOnce();
+    expect(ContainerGenerator).toHaveBeenCalledWith({
+      image: IMAGE_INSPECT_MOCK,
+      container: CONTAINER_INSPECT_MOCK,
+    });
+
+    // the output should match the mocked string
+    expect(result).toStrictEqual(CONTAINER_GENERATE_OUTPUT);
+  });
+});
+
+describe('image quadlets', () => {
+  test('should use the container and image service to inspect resources', async () => {
+    const podletJs = getService();
+
+    // generate container quadlet
+    const result = await podletJs.generate({
+      connection: CONTAINER_CONNECTION_IDENTIFIER,
+      type: QuadletType.IMAGE,
+      resourceId: IMAGE_INSPECT_MOCK.Id,
+    });
+
+    // Should get the corresponding engine id
+    expect(CONTAINER_SERVICE_MOCK.getEngineId).toHaveBeenCalledOnce();
+    expect(CONTAINER_SERVICE_MOCK.getEngineId).toHaveBeenCalledWith(CONTAINER_CONNECTION_IDENTIFIER);
+
+    // nothing related to containers
+    expect(CONTAINER_SERVICE_MOCK.inspectContainer).not.toHaveBeenCalledOnce();
+
+    // should get the image inspect info
+    expect(IMAGE_SERVICE_MOCK.inspectImage).toHaveBeenCalledOnce();
+    expect(IMAGE_SERVICE_MOCK.inspectImage).toHaveBeenCalledWith(ENGINE_ID_MOCK, IMAGE_INSPECT_MOCK.Id);
+
+    // should properly call the podlet-js image generator
+    expect(ImageGenerator).toHaveBeenCalledOnce();
+    expect(ImageGenerator).toHaveBeenCalledWith({
+      image: IMAGE_INSPECT_MOCK,
+    });
+
+    // the output should match the mocked string
+    expect(result).toStrictEqual(IMAGE_GENERATE_OUTPUT);
+  });
+});
+
+describe('compose', () => {
+  const COMPOSE_RAW_MOCK = 'compose-content';
+  const COMPOSE_MOCK: Compose = {
+    toKubePlay: vi.fn(),
+  } as unknown as Compose;
+
+  const KUBE_MOCK: string = 'kube-content';
+
+  beforeEach(() => {
+    vi.mocked(readFile).mockResolvedValue(COMPOSE_RAW_MOCK);
+    vi.mocked(Compose.fromString).mockReturnValue(COMPOSE_MOCK);
+
+    vi.mocked(COMPOSE_MOCK.toKubePlay).mockReturnValue(KUBE_MOCK);
+  });
+
+  test('should read the provided file', async () => {
+    const podletJs = getService();
+
+    const result = await podletJs.compose({
+      type: QuadletType.KUBE,
+      filepath: 'dummy-path',
+    });
+
+    // ensure the right file is read
+    expect(readFile).toHaveBeenCalledOnce();
+    expect(readFile).toHaveBeenCalledWith('dummy-path', { encoding: 'utf8' });
+
+    // expect raw content to be used
+    expect(Compose.fromString).toHaveBeenCalledOnce();
+    expect(Compose.fromString).toHaveBeenCalledWith(COMPOSE_RAW_MOCK);
+
+    // ensure the compose instance is converted to kube play
+    expect(COMPOSE_MOCK.toKubePlay).toHaveBeenCalledOnce();
+
+    expect(result).toStrictEqual(KUBE_MOCK);
+  });
+});

--- a/packages/backend/src/services/podlet-js-service.ts
+++ b/packages/backend/src/services/podlet-js-service.ts
@@ -1,0 +1,92 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import type { ProviderContainerConnectionIdentifierInfo } from '/@shared/src/models/provider-container-connection-identifier-info';
+import { QuadletType } from '/@shared/src/utils/quadlet-type';
+import type { ContainerService } from './container-service';
+import type { ImageService } from './image-service';
+import type { ContainerInspectInfo, ImageInspectInfo } from '@podman-desktop/api';
+import { ContainerGenerator, Compose, ImageGenerator } from 'podlet-js';
+import { readFile } from 'node:fs/promises';
+
+interface Dependencies {
+  containers: ContainerService;
+  images: ImageService;
+}
+
+export class PodletJsService {
+  constructor(protected dependencies: Dependencies) {}
+
+  /**
+   * Using the `podlet-js` package, generate a stringify {@link ContainerQuadlet}
+   * @param engineId
+   * @param containerId
+   * @protected
+   */
+  protected async generateContainer(engineId: string, containerId: string): Promise<string> {
+    const container: ContainerInspectInfo = await this.dependencies.containers.inspectContainer(engineId, containerId);
+
+    const image: ImageInspectInfo = await this.dependencies.images.inspectImage(engineId, container.Image);
+
+    return new ContainerGenerator({
+      container,
+      image,
+    }).generate();
+  }
+
+  /**
+   * Using the `podlet-js` package, generate a stringify {@link ImageQuadlet}
+   * @param engineId
+   * @param imageId
+   * @protected
+   */
+  protected async generateImage(engineId: string, imageId: string): Promise<string> {
+    const image: ImageInspectInfo = await this.dependencies.images.inspectImage(engineId, imageId);
+
+    return new ImageGenerator({
+      image: image,
+    }).generate();
+  }
+
+  public async generate(options: {
+    connection: ProviderContainerConnectionIdentifierInfo;
+    type: QuadletType;
+    resourceId: string;
+  }): Promise<string> {
+    // Get the engine id
+    const engineId = await this.dependencies.containers.getEngineId(options.connection);
+
+    switch (options.type) {
+      case QuadletType.CONTAINER:
+        return await this.generateContainer(engineId, options.resourceId);
+      case QuadletType.IMAGE:
+        return await this.generateImage(engineId, options.resourceId);
+      default:
+        throw new Error(`cannot generate quadlet type ${options.type}: unsupported`);
+    }
+  }
+
+  public async compose(options: {
+    filepath: string;
+    type: QuadletType.CONTAINER | QuadletType.KUBE | QuadletType.POD;
+  }): Promise<string> {
+    if (options.type !== QuadletType.KUBE) throw new Error(`cannot generate quadlet type ${options.type}: unsupported`);
+
+    const content = await readFile(options.filepath, { encoding: 'utf8' });
+    return Compose.fromString(content).toKubePlay();
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,9 @@ importers:
       js-yaml:
         specifier: ^4.1.0
         version: 4.1.0
+      podlet-js:
+        specifier: workspace:^
+        version: link:../podlet-js
       semver:
         specifier: ^7.7.1
         version: 7.7.1


### PR DESCRIPTION
## Description

Creating `PodletJsService` which will replace (in a near future hopefully :crossed_fingers: ) the existing `PodletCliService`

> :information_source: the code is independent and not exposed to the user, therefore no breaking change

## Notes

- Adding podlet-js as dependencies of the backend
- Adding build step in CI (since we need to have podlet-js built) to run typescheck etc.

## Related issues

Part of https://github.com/podman-desktop/extension-podman-quadlet/issues/298

## Testing

- [x] unit tests has been added

