### PR TITLE
fix(e2e): exclude podman-desktop folder from artifact

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -259,6 +259,6 @@ jobs:
         with:
           name: e2e-pr-check-${{ matrix.os }}
           path: |
-            ./**/tests/**/output/
-            !podman-desktop/**
+            tests/playwright/output/
+            tests/playwright/tests/
 

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -258,5 +258,7 @@ jobs:
         if: always()
         with:
           name: e2e-pr-check-${{ matrix.os }}
-          path: ./**/tests/**/output/
+          path: |
+            ./**/tests/**/output/
+            !podman-desktop/**
 


### PR DESCRIPTION
## Description

Following discussion with @odockal , the podman-desktop folder can be excluded, in fact we only interested in two folder, the `tests/playwright/output` (html result) and the `tests/playwright/tests` (video and configuration)

## Related issue

Fixes https://github.com/podman-desktop/extension-podman-quadlet/issues/420