### PR TITLE
docs(README): adding coverage badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Podman Desktop Quadlet Extension
 
+[![codecov](https://codecov.io/github/podman-desktop/extension-podman-quadlet/graph/badge.svg?token=P885ZCDJA7)](https://codecov.io/github/podman-desktop/extension-podman-quadlet)
+
 ## Overview
 
 ![quadlet-list.png](images/quadlet-list.png)


### PR DESCRIPTION
Following https://github.com/podman-desktop/extension-podman-quadlet/pull/439 adding the coverage badge to the README