### PR TITLE
chore(pr-check): update workflow with build step

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -40,6 +40,9 @@ jobs:
       - name: Execute pnpm
         run: pnpm install --frozen-lockfile
 
+      - name: Execute Build
+        run: pnpm build
+
       - name: Run linter
         run: pnpm lint:check
 
@@ -75,6 +78,9 @@ jobs:
 
       - name: Execute pnpm
         run: pnpm install
+
+      - name: Execute Build
+        run: pnpm build
 
       - name: Run unit tests
         run: pnpm test:unit


### PR DESCRIPTION
## Description

As per requested in https://github.com/podman-desktop/extension-podman-quadlet/pull/416#discussion_r2020478226 updating the pr-checks in a separate PR.

> Currently packages are independent, so we do not need to build before running typecheck and unit tests. However, with https://github.com/podman-desktop/extension-podman-quadlet/pull/416 the `backend` packages will depends on `podlet-js` and typecheck will fails as no type are available if the package is not built.

## Related issues

Required for
- https://github.com/podman-desktop/extension-podman-quadlet/issues/298