### PR TITLE
feat(backend): parse quadlets requires

### DIFF
--- a/packages/backend/src/apis/quadlet-api-impl.spec.ts
+++ b/packages/backend/src/apis/quadlet-api-impl.spec.ts
@@ -68,6 +68,7 @@ const QUADLET_MOCK: Quadlet & { service: string } = {
   state: 'unknown',
   content: 'dummy-content',
   type: QuadletType.CONTAINER,
+  requires: [],
 };
 
 beforeEach(() => {

--- a/packages/backend/src/models/quadlet.ts
+++ b/packages/backend/src/models/quadlet.ts
@@ -33,4 +33,9 @@ export interface Quadlet {
    * quadlet have a type based on their extension (.container, .image etc.)
    */
   type: QuadletType;
+  /**
+   * quadlet can depend on other services (which may be also quadlets)
+   * @remarks the string are the service name, not the quadlet ids.
+   */
+  requires: Array<string>;
 }

--- a/packages/backend/src/services/quadlet-service.spec.ts
+++ b/packages/backend/src/services/quadlet-service.spec.ts
@@ -101,6 +101,7 @@ const QUADLET_MOCK: Quadlet & { service: string } = {
   state: 'unknown',
   content: 'dummy-content',
   type: QuadletType.CONTAINER,
+  requires: [],
 };
 
 const KUBE_QUADLET_MOCK: Quadlet & { service: string } = {
@@ -110,6 +111,7 @@ const KUBE_QUADLET_MOCK: Quadlet & { service: string } = {
   state: 'unknown',
   content: 'dummy-content',
   type: QuadletType.KUBE,
+  requires: [],
 };
 
 const SERVICE_LESS_QUADLET_MOCK: Quadlet = {
@@ -118,6 +120,7 @@ const SERVICE_LESS_QUADLET_MOCK: Quadlet = {
   state: 'unknown',
   content: 'dummy-content',
   type: QuadletType.CONTAINER,
+  requires: [],
 };
 
 const PROGRESS_REPORT: Progress<{ message?: string; increment?: number }> = {
@@ -377,6 +380,7 @@ describe('QuadletService#remove', () => {
     path: `config/quadlet-${index}.container`,
     content: 'dummy-content',
     type: QuadletType.CONTAINER,
+    requires: [],
   }));
 
   beforeEach(() => {

--- a/packages/backend/src/utils/parsers/quadlet-dryrun-parser.ts
+++ b/packages/backend/src/utils/parsers/quadlet-dryrun-parser.ts
@@ -71,6 +71,7 @@ export class QuadletDryRunParser extends Parser<RunResult & { exitCode?: number 
         path: path,
         state: 'error',
         type: new QuadletExtensionParser(path).parse(),
+        requires: [], // cannot detect requires
       });
 
       return accumulator;

--- a/packages/backend/src/utils/parsers/quadlet-unit-parser.spec.ts
+++ b/packages/backend/src/utils/parsers/quadlet-unit-parser.spec.ts
@@ -36,6 +36,34 @@ SourcePath=/home/user/.config/containers/systemd/nginx2.container
 RequiresMountsFor=%t/containers
 `;
 
+const REQUIRES_EXAMPLE = `
+# hello.container
+[X-Container]
+Image=nginx.image
+PublishPort=8888:80
+
+[Service]
+Restart=always
+Environment=PODMAN_SYSTEMD_UNIT=%n
+KillMode=mixed
+ExecStop=/usr/bin/podman rm -v -f -i --cidfile=%t/%N.cid
+ExecStopPost=-/usr/bin/podman rm -v -f -i --cidfile=%t/%N.cid
+Delegate=yes
+Type=notify
+NotifyAccess=all
+SyslogIdentifier=%N
+ExecStart=/usr/bin/podman run --name systemd-%N --cidfile=%t/%N.cid --replace --rm --cgroups=split --sdnotify=conmon -d --publish 8888:80 docker.io/library/nginx:latest
+
+[Unit]
+Wants=podman-user-wait-network-online.service
+After=podman-user-wait-network-online.service
+Requires=hello-world.image
+SourcePath=/home/axel7083/.config/containers/systemd/hello.container
+Requires=nginx-image.service
+After=nginx-image.service
+RequiresMountsFor=%t/containers
+`;
+
 const DUMMY_SERVICE_NAME = 'dummy.container';
 
 test('expect path to be properly extracted', async () => {
@@ -61,4 +89,11 @@ test('expect content to be identical to input', async () => {
       service: DUMMY_SERVICE_NAME,
     }),
   );
+});
+
+test('expect requires to be properly parsed', async () => {
+  const parser = new QuadletUnitParser(DUMMY_SERVICE_NAME, REQUIRES_EXAMPLE);
+  const result = parser.parse();
+
+  expect(result.requires).toStrictEqual(['hello-world.image', 'nginx-image.service']);
 });

--- a/packages/frontend/src/lib/monaco-editor/KubeYamlEditor.spec.ts
+++ b/packages/frontend/src/lib/monaco-editor/KubeYamlEditor.spec.ts
@@ -58,6 +58,7 @@ const KUBE_QUADLET: QuadletInfo & { type: QuadletType.KUBE } = {
   content: 'dummy-content',
   state: 'active',
   connection: PODMAN_MACHINE_DEFAULT,
+  requires: [],
 };
 
 test('ensure reload button is visible', async () => {

--- a/packages/frontend/src/lib/table/QuadletActions.spec.ts
+++ b/packages/frontend/src/lib/table/QuadletActions.spec.ts
@@ -51,6 +51,7 @@ const QUADLET_MOCK: QuadletInfo = {
   path: `bar/foo.container`,
   connection: PROVIDER_MOCK,
   type: QuadletType.CONTAINER,
+  requires: [],
 };
 
 test('expect active quadlet to have stop enabled', async () => {

--- a/packages/frontend/src/lib/table/QuadletName.spec.ts
+++ b/packages/frontend/src/lib/table/QuadletName.spec.ts
@@ -46,6 +46,7 @@ const QUADLET_MOCK: QuadletInfo = {
   path: `bar/foo.container`,
   connection: PROVIDER_MOCK,
   type: QuadletType.CONTAINER,
+  requires: [],
 };
 
 test('expect quadlet with service name to use it', () => {

--- a/packages/frontend/src/lib/table/QuadletStatus.spec.ts
+++ b/packages/frontend/src/lib/table/QuadletStatus.spec.ts
@@ -41,6 +41,7 @@ const QUADLET_MOCK: QuadletInfo = {
   path: `bar/foo.container`,
   connection: PROVIDER_MOCK,
   type: QuadletType.CONTAINER,
+  requires: [],
 };
 
 type TestCase = {

--- a/packages/frontend/src/pages/QuadletDetails.spec.ts
+++ b/packages/frontend/src/pages/QuadletDetails.spec.ts
@@ -63,6 +63,7 @@ const CONTAINER_QUADLET_MOCK: QuadletInfo & { service: string } = {
   state: 'active',
   path: `bar/foo.container`,
   type: QuadletType.CONTAINER,
+  requires: [],
 };
 
 const IMAGE_QUADLET_MOCK: QuadletInfo & { service: string } = {
@@ -74,6 +75,7 @@ const IMAGE_QUADLET_MOCK: QuadletInfo & { service: string } = {
   state: 'active',
   path: `bar/foo.image`,
   type: QuadletType.IMAGE,
+  requires: [],
 };
 
 const INVALID_IMAGE_QUADLET_MOCK: QuadletInfo = {
@@ -83,6 +85,7 @@ const INVALID_IMAGE_QUADLET_MOCK: QuadletInfo = {
   state: 'active',
   path: `bar/foo.image`,
   type: QuadletType.IMAGE,
+  requires: [],
 };
 
 const KUBE_QUADLET_MOCK: QuadletInfo = {
@@ -93,6 +96,7 @@ const KUBE_QUADLET_MOCK: QuadletInfo = {
   state: 'active',
   path: `bar/foo.kube`,
   type: QuadletType.KUBE,
+  requires: [],
 };
 
 beforeEach(() => {

--- a/packages/frontend/src/pages/QuadletsList.spec.ts
+++ b/packages/frontend/src/pages/QuadletsList.spec.ts
@@ -76,6 +76,7 @@ const QUADLETS_MOCK: Array<QuadletInfo & { service: string }> = Array.from({ len
   state: 'active',
   path: `bar/foo-${index}.container`,
   type: QuadletType.CONTAINER,
+  requires: [],
 }));
 
 beforeEach(() => {

--- a/packages/frontend/src/utils/quadlet.spec.ts
+++ b/packages/frontend/src/utils/quadlet.spec.ts
@@ -37,6 +37,7 @@ test.each(Object.values(QuadletType).filter(type => type !== QuadletType.KUBE))(
         content: 'dummy-content',
         state: 'active',
         connection: PODMAN_MACHINE_DEFAULT,
+        requires: [],
       }),
     ).toBeFalsy();
   },
@@ -51,6 +52,7 @@ test(`expect ${QuadletType.KUBE} to be recognised`, () => {
       content: 'dummy-content',
       state: 'active',
       connection: PODMAN_MACHINE_DEFAULT,
+      requires: [],
     }),
   ).toBeTruthy();
 });

--- a/packages/shared/src/models/quadlet-info.ts
+++ b/packages/shared/src/models/quadlet-info.ts
@@ -39,4 +39,9 @@ export interface QuadletInfo {
    * quadlet have a type based on their extension (.container, .image etc.)
    */
   type: QuadletType;
+  /**
+   * quadlet can depend on other services (which may be also quadlets)
+   * @remarks the string are the service name, not the quadlet ids.
+   */
+  requires: Array<string>;
 }


### PR DESCRIPTION
## Description

Quadlets can depends on each other, meaning `foo.container` could defined `bar.image` as its image, giving a direct link between those two.

Thankfully, the Quadlet generator gave us this information inside the `[Unit]` section of the generated Quadlet. We can simply parse it.

## Related issue

First part of https://github.com/podman-desktop/extension-podman-quadlet/issues/427 (backend part)

## Testing

- [x] unit tests has been added

You can check the full branch to see the full feature  [axel7083#feature/quadlet-require/full](https://github.com/axel7083/extension-podman-quadlet/tree/feature/quadlet-require/full)