### PR TITLE
refactor(frontend): make monaco-editor dynamic import

### DIFF
--- a/packages/frontend/src/App.svelte
+++ b/packages/frontend/src/App.svelte
@@ -12,6 +12,8 @@ import { Messages } from '/@shared/src/messages';
 import type { Unsubscriber } from 'svelte/store';
 import QuadletGenerate from '/@/pages/QuadletGenerate.svelte';
 import QuadletCompose from '/@/pages/QuadletCompose.svelte';
+// import globally the monaco environment
+import './lib/monaco-editor/monaco-environment';
 
 router.mode.hash();
 let isMounted = $state(false);

--- a/packages/frontend/src/lib/forms/compose/QuadletComposeForm.svelte
+++ b/packages/frontend/src/lib/forms/compose/QuadletComposeForm.svelte
@@ -218,7 +218,7 @@ function close(): void {
         id="quadlet-name" />
 
       <div class="h-[400px] pt-4">
-        <QuadletEditor validate bind:content={quadlet} />
+        <QuadletEditor bind:content={quadlet} />
       </div>
 
       <div class="w-full flex flex-row gap-x-2 justify-end pt-4">

--- a/packages/frontend/src/lib/forms/quadlet/QuadletGenerateForm.svelte
+++ b/packages/frontend/src/lib/forms/quadlet/QuadletGenerateForm.svelte
@@ -250,7 +250,7 @@ function resetGenerate(): void {
         id="quadlet-name" />
 
       <div class="h-[400px] pt-4">
-        <QuadletEditor validate bind:content={quadlet} />
+        <QuadletEditor bind:content={quadlet} />
       </div>
       {#if error}
         <ErrorMessage error={error} />

--- a/packages/frontend/src/lib/monaco-editor/MonacoEditor.svelte
+++ b/packages/frontend/src/lib/monaco-editor/MonacoEditor.svelte
@@ -1,17 +1,14 @@
 <script lang="ts">
 import { onDestroy, onMount } from 'svelte';
 import type * as Monaco from 'monaco-editor/esm/vs/editor/editor.api';
-import { Range } from 'monaco-editor';
-import './monaco';
 import type { HTMLAttributes } from 'svelte/elements';
-import type { Glyph } from './glyph';
+import { MonacoManager } from '/@/lib/monaco-editor/monaco';
 
 interface Props extends HTMLAttributes<HTMLElement> {
   content: string;
   language: string;
   readOnly?: boolean;
   noMinimap?: boolean;
-  glyphs?: Glyph[];
   onChange?: (content: string) => void;
 }
 
@@ -19,7 +16,6 @@ let {
   content = $bindable(),
   language,
   readOnly = false,
-  glyphs = [],
   onChange,
   noMinimap,
   class: className,
@@ -28,110 +24,29 @@ let {
 
 let editorInstance: Monaco.editor.IStandaloneCodeEditor;
 let editorContainer: HTMLElement;
-let decorationCollection: Monaco.editor.IEditorDecorationsCollection | undefined = $state();
-
-function getTerminalBg(): string {
-  const app = document.getElementById('app');
-  if (!app) throw new Error('cannot found app element');
-  const style = window.getComputedStyle(app);
-
-  let color = style.getPropertyValue('--pd-terminal-background').trim();
-
-  // convert to 6 char RGB value since some things don't support 3 char format
-  if (color?.length < 6) {
-    color = color
-      .split('')
-      .map(c => {
-        return c === '#' ? c : c + c;
-      })
-      .join('');
-  }
-  return color;
-}
-
-export function updateDecorations(): void {
-  if (!editorInstance?.getModel()) return;
-
-  const model = editorInstance.getModel();
-  if (!model) return;
-
-  const decorations: Monaco.editor.IModelDeltaDecoration[] = [];
-
-  const lines = model.getLinesContent();
-
-  glyphs.forEach(({ regex, classes, tooltip }) => {
-    const matcher = new RegExp(regex);
-    lines.forEach((lineContent, index) => {
-      if (lineContent === regex || matcher.test(lineContent)) {
-        const lineNumber = index + 1; // Line starts at index + 1 in Monaco
-        decorations.push({
-          range: new Range(lineNumber, 1, lineNumber, 1),
-          options: {
-            isWholeLine: true,
-            marginClassName: classes,
-            glyphMarginHoverMessage: {
-              value: tooltip,
-            },
-          },
-        });
-      }
-    });
-  });
-
-  if (!decorationCollection) {
-    decorationCollection = editorInstance.createDecorationsCollection(decorations);
-  } else {
-    // replacing
-    decorationCollection.set(decorations);
-  }
-}
 
 onMount(async () => {
-  const terminalBg = getTerminalBg();
-  const isDarkTheme: boolean = terminalBg === '#000000';
+  const monaco = await MonacoManager.getMonaco();
 
-  // solution from https://github.com/vitejs/vite/discussions/1791#discussioncomment-9281911
-  import('monaco-editor/esm/vs/editor/editor.api')
-    .then(monaco => {
-      // define custom theme
-      monaco.editor.defineTheme('podmanDesktopTheme', {
-        base: isDarkTheme ? 'vs-dark' : 'vs',
-        inherit: true,
-        rules: [{ token: 'custom-color', background: terminalBg }],
-        colors: {
-          'editor.background': terminalBg,
-          // make the --vscode-focusBorder transparent
-          focusBorder: '#00000000',
-        },
-      });
+  editorInstance = monaco.editor.create(editorContainer, {
+    value: content,
+    language: language,
+    automaticLayout: true,
+    scrollBeyondLastLine: false,
+    readOnly: readOnly,
+    theme: MonacoManager.getThemeName(),
+    minimap: {
+      enabled: !noMinimap,
+    },
+  });
 
-      editorInstance = monaco.editor.create(editorContainer, {
-        value: content,
-        language: language,
-        automaticLayout: true,
-        scrollBeyondLastLine: false,
-        readOnly: readOnly,
-        theme: 'podmanDesktopTheme',
-        glyphMargin: true, // Enable glyph margin
-        minimap: {
-          enabled: !noMinimap,
-        },
-      });
-
-      editorInstance.onDidChangeModelContent(() => {
-        content = editorInstance.getValue();
-        updateDecorations();
-        onChange?.(content);
-      });
-
-      // Initial decoration setup
-      updateDecorations();
-    })
-    .catch(console.error);
+  editorInstance.onDidChangeModelContent(() => {
+    content = editorInstance.getValue();
+    onChange?.(content);
+  });
 });
 
 onDestroy(() => {
-  decorationCollection?.clear();
   editorInstance?.dispose();
 });
 </script>

--- a/packages/frontend/src/lib/monaco-editor/QuadletEditor.svelte
+++ b/packages/frontend/src/lib/monaco-editor/QuadletEditor.svelte
@@ -1,53 +1,17 @@
 <script lang="ts">
 import MonacoEditor from '/@/lib/monaco-editor/MonacoEditor.svelte';
-import { quadletAPI } from '/@/api/client';
-import type { Glyph } from '/@/lib/monaco-editor/glyph';
-import { debounce } from '/@/utils/debounce';
 
 interface Props {
   content: string;
-  validate: boolean;
   readOnly?: boolean;
 }
 
-let { content = $bindable(), validate, readOnly }: Props = $props();
-
-let glyphs: Glyph[] = $state([]);
-let editor: MonacoEditor;
-let requestId = 0;
-
-function onValidate(nContent: string): void {
-  if (!validate) return;
-  const current = ++requestId;
-
-  quadletAPI
-    .validate($state.snapshot(nContent))
-    .then(checks => {
-      glyphs = checks.map(check => ({
-        tooltip: check.message,
-        classes: 'fa-solid fa-circle-exclamation monaco-glyph',
-        regex: check.line,
-      }));
-    })
-    .catch((err: unknown) => {
-      if (current === requestId - 1) {
-        console.debug('validate error', err);
-        glyphs = []; // cleanup
-      }
-    })
-    .finally(() => {
-      // force update the decorations
-      editor.updateDecorations();
-    });
-}
+let { content = $bindable(), readOnly }: Props = $props();
 </script>
 
 <MonacoEditor
-  bind:this={editor}
   class="h-full"
-  glyphs={glyphs}
-  onChange={debounce(onValidate)}
   readOnly={readOnly}
   noMinimap
   bind:content={content}
-  language="ini" />
+  language="javascript" />

--- a/packages/frontend/src/lib/monaco-editor/monaco-environment.ts
+++ b/packages/frontend/src/lib/monaco-editor/monaco-environment.ts
@@ -1,0 +1,10 @@
+import editorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker';
+
+self.MonacoEnvironment = {
+  getWorker(_: unknown): Worker {
+    console.log('loading editor worker');
+    return new editorWorker();
+  },
+};
+
+console.log(self.MonacoEnvironment);

--- a/packages/frontend/src/lib/monaco-editor/monaco.ts
+++ b/packages/frontend/src/lib/monaco-editor/monaco.ts
@@ -1,10 +1,70 @@
-import * as monaco from 'monaco-editor';
-import editorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker';
+import type * as Monaco from 'monaco-editor/esm/vs/editor/editor.api';
 
-self.MonacoEnvironment = {
-  getWorker(_: unknown): Worker {
-    return new editorWorker();
-  },
-};
+export class MonacoManager {
+  protected static monaco: typeof Monaco | undefined;
 
-monaco.languages.typescript?.typescriptDefaults?.setEagerModelSync(true);
+  protected static async importLanguages(): Promise<Awaited<unknown>[]> {
+    return Promise.all([
+      import('monaco-editor/esm/vs/basic-languages/ini/ini.contribution'),
+      import('monaco-editor/esm/vs/basic-languages/yaml/yaml.contribution'),
+    ]);
+  }
+
+  static async getMonaco(): Promise<typeof Monaco> {
+    if (MonacoManager.monaco) return MonacoManager.monaco;
+
+    // import languages dynamically
+    await this.importLanguages();
+
+    // import monaco editor dynamically
+    this.monaco = await import('monaco-editor/esm/vs/editor/editor.api');
+    this.registerTheme();
+
+    console.log('languages',this.monaco.languages.getLanguages());
+
+    // return the full monaco
+    return this.monaco;
+  }
+
+  public static getThemeName(): string {
+    return 'podmanDesktopTheme';
+  }
+
+  protected static registerTheme(): void {
+    if (!MonacoManager.monaco) throw new Error('cannot register theme if monaco is not imported');
+
+    const terminalBg = this.getTerminalBg();
+    const isDarkTheme: boolean = terminalBg === '#000000';
+
+    // define custom theme
+    MonacoManager.monaco.editor.defineTheme(MonacoManager.getThemeName(), {
+      base: isDarkTheme ? 'vs-dark' : 'vs',
+      inherit: true,
+      rules: [{ token: 'custom-color', background: terminalBg }],
+      colors: {
+        'editor.background': terminalBg,
+        // make the --vscode-focusBorder transparent
+        focusBorder: '#00000000',
+      },
+    });
+  }
+
+  protected static getTerminalBg(): string {
+    const app = document.getElementById('app');
+    if (!app) throw new Error('cannot found app element');
+    const style = window.getComputedStyle(app);
+
+    let color = style.getPropertyValue('--pd-terminal-background').trim();
+
+    // convert to 6 char RGB value since some things don't support 3 char format
+    if (color?.length < 6) {
+      color = color
+        .split('')
+        .map(c => {
+          return c === '#' ? c : c + c;
+        })
+        .join('');
+    }
+    return color;
+  }
+}

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -47,6 +47,7 @@ export default defineConfig({
     },
   },
   build: {
+    modulePreload: false,
     sourcemap: true,
     outDir: '../backend/media',
     assetsDir: '.',


### PR DESCRIPTION
## Description

Making `monaco-editor` package **smaller** . We are importing 191 default languages, we only need two **ini** and **yaml**.

We have a static import for all monaco package, which is problematic: the time the webview takes to load is pretty long (can go up to 2 seconds on my computer).

## Performances

**Before**

Currently 7.61MB

![image](https://github.com/user-attachments/assets/3e30dff1-dc69-4721-9a56-0b292e35d3e9)

![image](https://github.com/user-attachments/assets/12645f65-4598-4c95-a03f-3f785efdc0ae)

**After**

After the update 5.28MB (only importing what is needed)

![image](https://github.com/user-attachments/assets/45c111ef-b913-41d9-847e-9fb915f0197e)

![image](https://github.com/user-attachments/assets/881794a2-2bc7-4e90-93f7-abbdab403727)

## Related issues

Fixes https://github.com/podman-desktop/extension-podman-quadlet/issues/489

Requires
- https://github.com/podman-desktop/podman-desktop/issues/12130

## Testing

e2e will fails because currently core of podman desktop has strict rule on headers to use, and are incompatible with how dynamic import works.