### PR TITLE
refactor(monaco): import once, use many

### DIFF
--- a/packages/frontend/src/App.svelte
+++ b/packages/frontend/src/App.svelte
@@ -12,6 +12,8 @@ import { Messages } from '/@shared/src/messages';
 import type { Unsubscriber } from 'svelte/store';
 import QuadletGenerate from '/@/pages/QuadletGenerate.svelte';
 import QuadletCompose from '/@/pages/QuadletCompose.svelte';
+// import globally the monaco environment
+import './lib/monaco-editor/monaco-environment';
 
 router.mode.hash();
 let isMounted = $state(false);

--- a/packages/frontend/src/lib/monaco-editor/MonacoEditor.spec.ts
+++ b/packages/frontend/src/lib/monaco-editor/MonacoEditor.spec.ts
@@ -32,6 +32,7 @@ import { editor } from 'monaco-editor/esm/vs/editor/editor.api';
 vi.mock('monaco-editor/esm/vs/editor/editor.api', () => ({
   editor: {
     defineTheme: vi.fn(),
+    create: vi.fn(),
   },
 }));
 vi.mock('monaco-editor/esm/vs/basic-languages/ini/ini.contribution', () => ({}));

--- a/packages/frontend/src/lib/monaco-editor/MonacoEditor.spec.ts
+++ b/packages/frontend/src/lib/monaco-editor/MonacoEditor.spec.ts
@@ -26,6 +26,8 @@ import { editor } from 'monaco-editor/esm/vs/editor/editor.api';
 // mock all monaco core component
 vi.mock('monaco-editor');
 vi.mock('monaco-editor/esm/vs/editor/editor.api');
+vi.mock('monaco-editor/esm/vs/basic-languages/ini/ini.contribution');
+vi.mock('monaco-editor/esm/vs/basic-languages/yaml/yaml.contribution');
 
 const EDITOR_MOCK: editor.IStandaloneCodeEditor = {
   dispose: vi.fn(),

--- a/packages/frontend/src/lib/monaco-editor/MonacoEditor.spec.ts
+++ b/packages/frontend/src/lib/monaco-editor/MonacoEditor.spec.ts
@@ -23,11 +23,19 @@ import { beforeEach, test, vi, expect, describe } from 'vitest';
 import MonacoEditor from '/@/lib/monaco-editor/MonacoEditor.svelte';
 import { editor } from 'monaco-editor/esm/vs/editor/editor.api';
 
-// mock all monaco core component
-vi.mock('monaco-editor');
-vi.mock('monaco-editor/esm/vs/editor/editor.api');
-vi.mock('monaco-editor/esm/vs/basic-languages/ini/ini.contribution');
-vi.mock('monaco-editor/esm/vs/basic-languages/yaml/yaml.contribution');
+/**
+ * mock all monaco core component
+ *
+ * /!\ If your code is importing a mocked module, without any associated __mocks__ file or factory for this module,
+ * Vitest will mock the module itself by invoking it and mocking every export.
+ */
+vi.mock('monaco-editor/esm/vs/editor/editor.api', () => ({
+  editor: {
+    defineTheme: vi.fn(),
+  },
+}));
+vi.mock('monaco-editor/esm/vs/basic-languages/ini/ini.contribution', () => ({}));
+vi.mock('monaco-editor/esm/vs/basic-languages/yaml/yaml.contribution', () => ({}));
 
 const EDITOR_MOCK: editor.IStandaloneCodeEditor = {
   dispose: vi.fn(),

--- a/packages/frontend/src/lib/monaco-editor/MonacoEditor.svelte
+++ b/packages/frontend/src/lib/monaco-editor/MonacoEditor.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 import { onDestroy, onMount } from 'svelte';
 import type * as Monaco from 'monaco-editor/esm/vs/editor/editor.api';
-import './monaco';
 import type { HTMLAttributes } from 'svelte/elements';
+import { MonacoManager } from '/@/lib/monaco-editor/monaco';
 
 interface Props extends HTMLAttributes<HTMLElement> {
   content: string;
@@ -24,68 +24,29 @@ let {
 
 let editorInstance: Monaco.editor.IStandaloneCodeEditor;
 let editorContainer: HTMLElement;
-let decorationCollection: Monaco.editor.IEditorDecorationsCollection | undefined = $state();
-
-function getTerminalBg(): string {
-  const app = document.getElementById('app');
-  if (!app) throw new Error('cannot found app element');
-  const style = window.getComputedStyle(app);
-
-  let color = style.getPropertyValue('--pd-terminal-background').trim();
-
-  // convert to 6 char RGB value since some things don't support 3 char format
-  if (color?.length < 6) {
-    color = color
-      .split('')
-      .map(c => {
-        return c === '#' ? c : c + c;
-      })
-      .join('');
-  }
-  return color;
-}
 
 onMount(async () => {
-  const terminalBg = getTerminalBg();
-  const isDarkTheme: boolean = terminalBg === '#000000';
+  const monaco = await MonacoManager.getMonaco();
 
-  // solution from https://github.com/vitejs/vite/discussions/1791#discussioncomment-9281911
-  import('monaco-editor/esm/vs/editor/editor.api')
-    .then(monaco => {
-      // define custom theme
-      monaco.editor.defineTheme('podmanDesktopTheme', {
-        base: isDarkTheme ? 'vs-dark' : 'vs',
-        inherit: true,
-        rules: [{ token: 'custom-color', background: terminalBg }],
-        colors: {
-          'editor.background': terminalBg,
-          // make the --vscode-focusBorder transparent
-          focusBorder: '#00000000',
-        },
-      });
+  editorInstance = monaco.editor.create(editorContainer, {
+    value: content,
+    language: language,
+    automaticLayout: true,
+    scrollBeyondLastLine: false,
+    readOnly: readOnly,
+    theme: MonacoManager.getThemeName(),
+    minimap: {
+      enabled: !noMinimap,
+    },
+  });
 
-      editorInstance = monaco.editor.create(editorContainer, {
-        value: content,
-        language: language,
-        automaticLayout: true,
-        scrollBeyondLastLine: false,
-        readOnly: readOnly,
-        theme: 'podmanDesktopTheme',
-        minimap: {
-          enabled: !noMinimap,
-        },
-      });
-
-      editorInstance.onDidChangeModelContent(() => {
-        content = editorInstance.getValue();
-        onChange?.(content);
-      });
-    })
-    .catch(console.error);
+  editorInstance.onDidChangeModelContent(() => {
+    content = editorInstance.getValue();
+    onChange?.(content);
+  });
 });
 
 onDestroy(() => {
-  decorationCollection?.clear();
   editorInstance?.dispose();
 });
 </script>

--- a/packages/frontend/src/lib/monaco-editor/monaco-environment.ts
+++ b/packages/frontend/src/lib/monaco-editor/monaco-environment.ts
@@ -6,4 +6,3 @@ self.MonacoEnvironment = {
   },
 };
 
-console.log(self.MonacoEnvironment);

--- a/packages/frontend/src/lib/monaco-editor/monaco-environment.ts
+++ b/packages/frontend/src/lib/monaco-editor/monaco-environment.ts
@@ -1,0 +1,9 @@
+import editorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker';
+
+self.MonacoEnvironment = {
+  getWorker(_: unknown): Worker {
+    return new editorWorker();
+  },
+};
+
+console.log(self.MonacoEnvironment);

--- a/packages/frontend/src/lib/monaco-editor/monaco-environment.ts
+++ b/packages/frontend/src/lib/monaco-editor/monaco-environment.ts
@@ -5,4 +5,3 @@ self.MonacoEnvironment = {
     return new editorWorker();
   },
 };
-

--- a/packages/frontend/src/lib/monaco-editor/monaco.spec.ts
+++ b/packages/frontend/src/lib/monaco-editor/monaco.spec.ts
@@ -22,15 +22,19 @@ import { MonacoManager } from '/@/lib/monaco-editor/monaco';
 
 const BG_BLACK_COLOR = '#000000';
 
-// mock all monaco core component
-vi.mock('monaco-editor', () => ({
+/**
+ * mock all monaco core component
+ *
+ * /!\ If your code is importing a mocked module, without any associated __mocks__ file or factory for this module,
+ * Vitest will mock the module itself by invoking it and mocking every export.
+ */
+vi.mock('monaco-editor/esm/vs/editor/editor.api', () => ({
   editor: {
     defineTheme: vi.fn(),
   },
 }));
-vi.mock('monaco-editor/esm/vs/editor/editor.api');
-vi.mock('monaco-editor/esm/vs/basic-languages/ini/ini.contribution');
-vi.mock('monaco-editor/esm/vs/basic-languages/yaml/yaml.contribution');
+vi.mock('monaco-editor/esm/vs/basic-languages/ini/ini.contribution', () => ({}));
+vi.mock('monaco-editor/esm/vs/basic-languages/yaml/yaml.contribution', () => ({}));
 
 beforeEach(() => {
   vi.resetAllMocks();

--- a/packages/frontend/src/lib/monaco-editor/monaco.spec.ts
+++ b/packages/frontend/src/lib/monaco-editor/monaco.spec.ts
@@ -1,0 +1,57 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import '@testing-library/jest-dom/vitest';
+
+import { beforeEach, test, vi, expect } from 'vitest';
+import { MonacoManager } from '/@/lib/monaco-editor/monaco';
+
+const BG_BLACK_COLOR = '#000000';
+
+// mock all monaco core component
+vi.mock('monaco-editor', () => ({
+  editor: {
+    defineTheme: vi.fn(),
+  },
+}));
+vi.mock('monaco-editor/esm/vs/editor/editor.api');
+vi.mock('monaco-editor/esm/vs/basic-languages/ini/ini.contribution');
+vi.mock('monaco-editor/esm/vs/basic-languages/yaml/yaml.contribution');
+
+beforeEach(() => {
+  vi.resetAllMocks();
+
+  const APP = document.createElement('div');
+  APP.setAttribute('id', 'app');
+  APP.setAttribute('style', `--pd-terminal-background: ${BG_BLACK_COLOR};`); // Set your desired value
+
+  document.body.appendChild(APP);
+});
+
+test('importing monaco should register theme', async () => {
+  const monaco = await MonacoManager.getMonaco();
+
+  expect(monaco.editor.defineTheme).toHaveBeenCalledWith(
+    // theme registered should match theme name
+    MonacoManager.getThemeName(),
+    expect.objectContaining({
+      colors: expect.objectContaining({
+        'editor.background': BG_BLACK_COLOR,
+      }),
+    }),
+  );
+});

--- a/packages/frontend/src/lib/monaco-editor/monaco.ts
+++ b/packages/frontend/src/lib/monaco-editor/monaco.ts
@@ -1,10 +1,68 @@
-import * as monaco from 'monaco-editor';
-import editorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker';
+import type * as Monaco from 'monaco-editor/esm/vs/editor/editor.api';
 
-self.MonacoEnvironment = {
-  getWorker(_: unknown): Worker {
-    return new editorWorker();
-  },
-};
+export class MonacoManager {
+  protected static monaco: typeof Monaco | undefined;
 
-monaco.languages.typescript?.typescriptDefaults?.setEagerModelSync(true);
+  protected static async importLanguages(): Promise<Awaited<unknown>[]> {
+    return Promise.all([
+      import('monaco-editor/esm/vs/basic-languages/ini/ini.contribution'),
+      import('monaco-editor/esm/vs/basic-languages/yaml/yaml.contribution'),
+    ]);
+  }
+
+  static async getMonaco(): Promise<typeof Monaco> {
+    if (MonacoManager.monaco) return MonacoManager.monaco;
+
+    // import languages dynamically
+    await this.importLanguages();
+
+    // import monaco editor dynamically
+    this.monaco = await import('monaco-editor/esm/vs/editor/editor.api');
+    this.registerTheme();
+
+    // return the full monaco
+    return this.monaco;
+  }
+
+  public static getThemeName(): string {
+    return 'podmanDesktopTheme';
+  }
+
+  protected static registerTheme(): void {
+    if (!MonacoManager.monaco) throw new Error('cannot register theme if monaco is not imported');
+
+    const terminalBg = this.getTerminalBg();
+    const isDarkTheme: boolean = terminalBg === '#000000';
+
+    // define custom theme
+    MonacoManager.monaco.editor.defineTheme(MonacoManager.getThemeName(), {
+      base: isDarkTheme ? 'vs-dark' : 'vs',
+      inherit: true,
+      rules: [{ token: 'custom-color', background: terminalBg }],
+      colors: {
+        'editor.background': terminalBg,
+        // make the --vscode-focusBorder transparent
+        focusBorder: '#00000000',
+      },
+    });
+  }
+
+  protected static getTerminalBg(): string {
+    const app = document.getElementById('app');
+    if (!app) throw new Error('cannot found app element');
+    const style = window.getComputedStyle(app);
+
+    let color = style.getPropertyValue('--pd-terminal-background').trim();
+
+    // convert to 6 char RGB value since some things don't support 3 char format
+    if (color?.length < 6) {
+      color = color
+        .split('')
+        .map(c => {
+          return c === '#' ? c : c + c;
+        })
+        .join('');
+    }
+    return color;
+  }
+}

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -47,6 +47,10 @@ export default defineConfig({
     },
   },
   build: {
+    // vite module preload option create dynamically a <link rel="modulepreload" ../>
+    // preloading a module do not send referrer header
+    // due to limitation with how podman-desktop serve static content, we cannot make request without referrer
+    modulePreload: false,
     sourcemap: true,
     outDir: '../backend/media',
     assetsDir: '.',


### PR DESCRIPTION
## Description

Supersede https://github.com/podman-desktop/extension-podman-quadlet/pull/490 - enable dynamic import for monaco editor by removing all static import.

Creating a `MonacoManager` class being the only responsible of the import of the monaco module.

## Notes

⚠️ Vitest has a particularity, if you do `vi.mock(<module>)`, it will import the module and mock the content => for monaco this is bad, the module is very big. If we provide a factory, `vi.mock(<module>, () => ({}))` it don't import the module => good.

## Related issues

Fixes https://github.com/podman-desktop/extension-podman-quadlet/issues/489

## Testing

- Ensure that the monaco editor is accessible