### PR TITLE
feat(RPC): update DialogAPI  & implementation

### DIFF
--- a/packages/backend/src/apis/dialog-api-impl.ts
+++ b/packages/backend/src/apis/dialog-api-impl.ts
@@ -17,6 +17,7 @@
  ***********************************************************************/
 import type { DialogService } from '../services/dialog-service';
 import { DialogApi } from '/@shared/src/apis/dialog-api';
+import type { InputBoxOptions } from '/@shared/src/models/input-box-options';
 
 interface Dependencies {
   dialog: DialogService;
@@ -29,5 +30,13 @@ export class DialogApiImpl extends DialogApi {
 
   override showWarningMessage(message: string, ...items: string[]): Promise<string | undefined> {
     return this.dependencies.dialog.showWarningMessage(message, ...items);
+  }
+
+  override showInformationMessage(message: string, ...items: string[]): Promise<string | undefined> {
+    return this.dependencies.dialog.showInformationMessage(message, ...items);
+  }
+
+  override showInputBox(options: InputBoxOptions): Promise<string | undefined> {
+    return this.dependencies.dialog.showInputBox(options);
   }
 }

--- a/packages/backend/src/services/dialog-service.spec.ts
+++ b/packages/backend/src/services/dialog-service.spec.ts
@@ -15,7 +15,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
-import type { window } from '@podman-desktop/api';
+import type { InputBoxOptions, window } from '@podman-desktop/api';
 
 import { beforeEach, vi, test, expect } from 'vitest';
 import { DialogService } from './dialog-service';
@@ -26,16 +26,45 @@ beforeEach(() => {
 
 const WINDOWS_API_MOCK: typeof window = {
   showWarningMessage: vi.fn(),
+  showInputBox: vi.fn(),
+  showInformationMessage: vi.fn(),
 } as unknown as typeof window;
+
+function getDialogService(): DialogService {
+  return new DialogService({
+    windowApi: WINDOWS_API_MOCK,
+  });
+}
 
 test('expect DialogService#showWarningMessage to use windowApi#showWarningMessage', async () => {
   vi.mocked(WINDOWS_API_MOCK.showWarningMessage).mockResolvedValue('hello');
 
-  const dialog = new DialogService({
-    windowApi: WINDOWS_API_MOCK,
-  });
+  const dialog = getDialogService();
   const result = await dialog.showWarningMessage('foo.bar', 'hello', 'world');
   expect(result).toStrictEqual('hello');
 
   expect(WINDOWS_API_MOCK.showWarningMessage).toHaveBeenCalledWith('foo.bar', 'hello', 'world');
+});
+
+test('expect DialogService#showInputBox to use windowApi#showInputBox', async () => {
+  vi.mocked(WINDOWS_API_MOCK.showInputBox).mockResolvedValue('hello');
+  const options: InputBoxOptions = {
+    title: 'Foo title',
+  };
+
+  const dialog = getDialogService();
+  const result = await dialog.showInputBox(options);
+  expect(result).toStrictEqual('hello');
+
+  expect(WINDOWS_API_MOCK.showInputBox).toHaveBeenCalledWith(options);
+});
+
+test('expect DialogService#showInformationMessage to use windowApi#showInformationMessage', async () => {
+  vi.mocked(WINDOWS_API_MOCK.showInformationMessage).mockResolvedValue('hello');
+
+  const dialog = getDialogService();
+  const result = await dialog.showInformationMessage('foo.bar', 'hello', 'world');
+  expect(result).toStrictEqual('hello');
+
+  expect(WINDOWS_API_MOCK.showInformationMessage).toHaveBeenCalledWith('foo.bar', 'hello', 'world');
 });

--- a/packages/shared/src/apis/dialog-api.ts
+++ b/packages/shared/src/apis/dialog-api.ts
@@ -21,6 +21,6 @@ export abstract class DialogApi {
   static readonly CHANNEL: string = 'dialog-api';
 
   abstract showWarningMessage(message: string, ...items: string[]): Promise<string | undefined>;
-  abstract showInformationMessage(message: string, ...items: string[]): Promise<string | undefined> ;
+  abstract showInformationMessage(message: string, ...items: string[]): Promise<string | undefined>;
   abstract showInputBox(options: InputBoxOptions): Promise<string | undefined>;
 }

--- a/packages/shared/src/apis/dialog-api.ts
+++ b/packages/shared/src/apis/dialog-api.ts
@@ -15,9 +15,12 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
+import type { InputBoxOptions } from '../models/input-box-options';
 
 export abstract class DialogApi {
   static readonly CHANNEL: string = 'dialog-api';
 
   abstract showWarningMessage(message: string, ...items: string[]): Promise<string | undefined>;
+  abstract showInformationMessage(message: string, ...items: string[]): Promise<string | undefined> ;
+  abstract showInputBox(options: InputBoxOptions): Promise<string | undefined>;
 }

--- a/packages/shared/src/models/input-box-options.ts
+++ b/packages/shared/src/models/input-box-options.ts
@@ -15,24 +15,15 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
-import type { InputBoxOptions, window } from '@podman-desktop/api';
 
-interface Dependencies {
-  windowApi: typeof window;
-}
+export interface InputBoxOptions {
+  /**
+   * An optional string that represents the title of the input box.
+   */
+  title?: string;
 
-export class DialogService {
-  constructor(protected dependencies: Dependencies) {}
-
-  showWarningMessage(message: string, ...items: string[]): Promise<string | undefined> {
-    return this.dependencies.windowApi.showWarningMessage(message, ...items);
-  }
-
-  showInputBox(options: InputBoxOptions): Promise<string | undefined> {
-    return this.dependencies.windowApi.showInputBox(options);
-  }
-
-  showInformationMessage(message: string, ...items: string[]): Promise<string | undefined> {
-    return this.dependencies.windowApi.showInformationMessage(message, ...items);
-  }
+  /**
+   * The value to pre-fill in the input box.
+   */
+  value?: string;
 }


### PR DESCRIPTION
## Description

Exposing `showInformationMessage` and `showInputBox` to the frontend.

## Related issues

Required for
- https://github.com/podman-desktop/extension-podman-quadlet/issues/424