### PR TITLE
refactor(Quadlets): factorise `saveIntoMachine` and `updateIntoMachine`

### DIFF
--- a/packages/backend/src/apis/quadlet-api-impl.ts
+++ b/packages/backend/src/apis/quadlet-api-impl.ts
@@ -133,34 +133,20 @@ export class QuadletApiImpl extends QuadletApi {
     return this.dependencies.loggerService.disposeLogger(loggerId);
   }
 
-  override saveIntoMachine(options: {
-    connection: ProviderContainerConnectionIdentifierInfo;
-    quadlet: string;
-    name: string;
-  }): Promise<void> {
-    const providerConnection = this.dependencies.providers.getProviderContainerConnection(options.connection);
-
-    return this.dependencies.quadlet.saveIntoMachine({
-      ...options,
-      provider: providerConnection,
-    });
-  }
-
-  override updateIntoMachine(options: {
-    connection: ProviderContainerConnectionIdentifierInfo;
-    quadlet: string; // content
-    path: string;
-  }): Promise<void> {
-    const providerConnection = this.dependencies.providers.getProviderContainerConnection(options.connection);
-
-    return this.dependencies.quadlet.updateIntoMachine({
-      ...options,
-      provider: providerConnection,
-    });
-  }
-
   override async getSynchronisationInfo(): Promise<SynchronisationInfo[]> {
     return this.dependencies.quadlet.getSynchronisationInfo();
+  }
+
+  override writeIntoMachine(options: {
+    connection: ProviderContainerConnectionIdentifierInfo;
+    files: Array<{ filename: string; content: string }>;
+  }): Promise<void> {
+    const providerConnection = this.dependencies.providers.getProviderContainerConnection(options.connection);
+
+    return this.dependencies.quadlet.writeIntoMachine({
+      ...options,
+      provider: providerConnection,
+    });
   }
 
   override async getKubeYAML(connection: ProviderContainerConnectionIdentifierInfo, id: string): Promise<string> {

--- a/packages/backend/src/utils/telemetry-events.ts
+++ b/packages/backend/src/utils/telemetry-events.ts
@@ -6,6 +6,7 @@ export enum TelemetryEvents {
   // quadlet
   QUADLET_CREATE = 'quadlet-create',
   QUADLET_UPDATE = 'quadlet-update',
+  QUADLET_WRITE = 'quadlet-write',
   QUADLET_REMOVE = 'quadlet-remove',
   // systemd
   SYSTEMD_START = 'systemd-start',

--- a/packages/frontend/src/lib/forms/compose/QuadletComposeForm.svelte
+++ b/packages/frontend/src/lib/forms/compose/QuadletComposeForm.svelte
@@ -88,10 +88,14 @@ async function saveIntoMachine(): Promise<void> {
 
   loading = true;
   try {
-    await quadletAPI.saveIntoMachine({
+    await quadletAPI.writeIntoMachine({
       connection: $state.snapshot(selectedContainerProviderConnection),
-      name: quadletFilename,
-      quadlet: quadlet,
+      files: [
+        {
+          filename: quadletFilename,
+          content: quadlet,
+        },
+      ],
     });
     loaded = true;
   } catch (err: unknown) {

--- a/packages/frontend/src/lib/forms/quadlet/QuadletGenerateForm.svelte
+++ b/packages/frontend/src/lib/forms/quadlet/QuadletGenerateForm.svelte
@@ -88,12 +88,6 @@ function onError(err: string): void {
 function onGenerated(value: string): void {
   error = undefined;
   quadlet = value;
-
-  const comment = quadlet.split('\n')[0];
-  if (comment.startsWith('#')) {
-    const [name] = comment.substring(2).split('.');
-    quadletFilename = name;
-  }
 }
 
 async function generate(): Promise<void> {
@@ -226,14 +220,14 @@ function resetGenerate(): void {
 
       <!-- step 2 edit -->
     {:else if step === 'edit' && quadlet !== undefined}
-      <label for="quadlet-name" class="pt-4 block mb-2 font-bold text-[var(--pd-content-card-header-text)]"
-        >Quadlet name</label>
+      <label for="quadlet-filename" class="pt-4 block mb-2 font-bold text-[var(--pd-content-card-header-text)]"
+        >Quadlet filename</label>
       <Input
         class="grow"
-        name="quadlet name"
-        placeholder="Quadlet name (E.g. nginx-quadlet)"
+        name="quadlet filename"
+        placeholder="Quadlet filename (E.g. nginx.container)"
         bind:value={quadletFilename}
-        id="quadlet-name" />
+        id="quadlet-filename" />
 
       <div class="h-[400px] pt-4">
         <QuadletEditor bind:content={quadlet} />

--- a/packages/frontend/src/lib/forms/quadlet/QuadletGenerateForm.svelte
+++ b/packages/frontend/src/lib/forms/quadlet/QuadletGenerateForm.svelte
@@ -122,10 +122,14 @@ async function saveIntoMachine(): Promise<void> {
   if (!quadlet) throw new Error('generation invalid');
   loading = true;
   try {
-    await quadletAPI.saveIntoMachine({
+    await quadletAPI.writeIntoMachine({
       connection: $state.snapshot(selectedContainerProviderConnection),
-      name: quadletFilename,
-      quadlet: quadlet,
+      files: [
+        {
+          filename: quadletFilename,
+          content: quadlet,
+        },
+      ],
     });
     loaded = true;
   } catch (err: unknown) {

--- a/packages/frontend/src/pages/QuadletDetails.svelte
+++ b/packages/frontend/src/pages/QuadletDetails.svelte
@@ -108,10 +108,14 @@ async function save(): Promise<void> {
 
   loading = true;
   try {
-    await quadletAPI.updateIntoMachine({
+    await quadletAPI.writeIntoMachine({
       connection: { providerId: providerId, name: connection },
-      quadlet: quadletSource,
-      path: quadlet.path,
+      files: [
+        {
+          filename: quadlet.path,
+          content: quadletSource,
+        },
+      ],
     });
     // we should be good to consider we updated it
     originalSource = quadletSource;

--- a/packages/shared/src/apis/quadlet-api.ts
+++ b/packages/shared/src/apis/quadlet-api.ts
@@ -38,17 +38,13 @@ export abstract class QuadletApi {
     quadletId: string;
   }): Promise<string>;
   abstract disposeLogger(loggerId: string): Promise<void>;
-
-  abstract saveIntoMachine(options: {
+  /**
+   * Write files into the configured folder for Quadlets.
+   * @param options
+   */
+  abstract writeIntoMachine(options: {
     connection: ProviderContainerConnectionIdentifierInfo;
-    quadlet: string; // content
-    name: string; // filename
-  }): Promise<void>;
-
-  abstract updateIntoMachine(options: {
-    connection: ProviderContainerConnectionIdentifierInfo;
-    quadlet: string; // content
-    path: string;
+    files: Array<{ filename: string; content: string }>;
   }): Promise<void>;
 
   abstract getSynchronisationInfo(): Promise<SynchronisationInfo[]>;

--- a/packages/shared/src/messages/constants.ts
+++ b/packages/shared/src/messages/constants.ts
@@ -3,8 +3,7 @@ import { QuadletApi } from '../apis/quadlet-api';
 import { DialogApi } from '../apis/dialog-api';
 
 export const noTimeoutChannels: string[] = [
-  getChannel(QuadletApi, 'saveIntoMachine'),
   getChannel(DialogApi, 'showWarningMessage'),
   getChannel(QuadletApi, 'start'),
-  getChannel(QuadletApi, 'updateIntoMachine'),
+  getChannel(QuadletApi, 'writeIntoMachine'),
 ];

--- a/tests/playwright/src/model/quadlet-generate-page.ts
+++ b/tests/playwright/src/model/quadlet-generate-page.ts
@@ -36,7 +36,7 @@ export class QuadletGeneratePage extends QuadletBasePage {
     this.imageSelect = new SvelteSelect(this.webview, 'Select Image');
 
     // step 2
-    this.quadletName = this.webview.getByRole('textbox', { name: 'quadlet name' });
+    this.quadletName = this.webview.getByRole('textbox', { name: 'quadlet filename' });
     this.saveIntoMachine = this.webview.getByRole('button', { name: 'Load into machine' });
 
     // step 3

--- a/tests/playwright/src/quadlet-extension.spec.ts
+++ b/tests/playwright/src/quadlet-extension.spec.ts
@@ -194,15 +194,16 @@ test.describe.serial(`Podman Quadlet extension installation and verification`, {
       // wait for content to be available
       await playExpect
         .poll(
-          async (): Promise<string> => {
+          async (): Promise<boolean> => {
             const monacoEditor = generateForm.webview.locator('.monaco-editor').nth(0);
-            return (await monacoEditor.textContent()) ?? '';
+            const content = await monacoEditor.textContent();
+            return content?.includes('[Image]Arch=amd64OS=linuxImage=quay.io/podman/hello:latest') ?? false;
           },
           {
             timeout: 5_000,
           },
         )
-        .toContain('[Image]Arch=amd64OS=linuxImage=quay.io/podman/hello:latest');
+        .toBeTruthy();
 
       // put the filename
       await generateForm.quadletName.fill('hello.image');

--- a/tests/playwright/src/quadlet-extension.spec.ts
+++ b/tests/playwright/src/quadlet-extension.spec.ts
@@ -202,7 +202,7 @@ test.describe.serial(`Podman Quadlet extension installation and verification`, {
             timeout: 5_000,
           },
         )
-        .toContain('[Image]Arch=amd64Image=quay.io/podman/hello:latestOS=linux');
+        .toContain('[Image]Arch=amd64OS=linuxImage=quay.io/podman/hello:latest');
 
       // put the filename
       await generateForm.quadletName.fill('hello.image');

--- a/tests/playwright/src/quadlet-extension.spec.ts
+++ b/tests/playwright/src/quadlet-extension.spec.ts
@@ -194,16 +194,15 @@ test.describe.serial(`Podman Quadlet extension installation and verification`, {
       // wait for content to be available
       await playExpect
         .poll(
-          async (): Promise<boolean> => {
+          async (): Promise<string> => {
             const monacoEditor = generateForm.webview.locator('.monaco-editor').nth(0);
-            const content = await monacoEditor.textContent();
-            return content?.includes('[Image]Arch=amd64OS=linuxImage=quay.io/podman/hello:latest') ?? false;
+            return (await monacoEditor.textContent()) ?? '';
           },
           {
             timeout: 5_000,
           },
         )
-        .toBeTruthy();
+        .toContain('[Image]Arch=amd64Image=quay.io/podman/hello:latestOS=linux');
 
       // put the filename
       await generateForm.quadletName.fill('hello.image');

--- a/tests/playwright/src/quadlet-extension.spec.ts
+++ b/tests/playwright/src/quadlet-extension.spec.ts
@@ -205,8 +205,8 @@ test.describe.serial(`Podman Quadlet extension installation and verification`, {
         )
         .toBeTruthy();
 
-      // put the title
-      await generateForm.quadletName.fill('hello');
+      // put the filename
+      await generateForm.quadletName.fill('hello.image');
 
       // wait for saveIntoMachine button to be enabled
       await playExpect


### PR DESCRIPTION
## Description

Two function in the `QuadletAPI` doing almost the same things 
- `saveIntoMachine` which save quadlets
- `updateIntoMachine` which update quadlets

While working on https://github.com/podman-desktop/extension-podman-quadlet/issues/424 I had to create a new function, doing what the previous two were doing, but again slightly differently.

Let's save myself some sanity, and factorise all of them into a single `writeIntoMachine`.

## Testing

- [x]: e2e ensure no regression

**Manually**

1. generate a Quadlet from an existing image / container
2. assert it is nicely created and listed