### PR TITLE
chore(vitest): create `vitest.setup.ts` file

### DIFF
--- a/packages/backend/src/services/main-service.spec.ts
+++ b/packages/backend/src/services/main-service.spec.ts
@@ -16,7 +16,6 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 import type {
-  Disposable,
   env,
   ExtensionContext,
   extensions,
@@ -50,16 +49,6 @@ import { ImageApi } from '/@shared/src/apis/image-api';
 import { PodletApi } from '/@shared/src/apis/podlet-api';
 import { RoutingApi } from '/@shared/src/apis/routing-api';
 import { DialogApi } from '/@shared/src/apis/dialog-api';
-
-vi.mock('@podman-desktop/api', () => ({
-  Disposable: {
-    create: (fn: () => void): Disposable => ({ dispose: fn }),
-  },
-  CancellationTokenSource: vi.fn(),
-  Uri: {
-    joinPath: vi.fn(),
-  },
-}));
 
 // mock message-proxy
 vi.mock('/@shared/src/messages/message-proxy');

--- a/packages/backend/src/services/podman-service.spec.ts
+++ b/packages/backend/src/services/podman-service.spec.ts
@@ -2,7 +2,6 @@
  * @author axel7083
  */
 import type {
-  Disposable,
   env as envApi,
   Extension,
   extensions,
@@ -24,13 +23,6 @@ import { join } from 'node:path/posix';
 
 vi.mock(import('node:fs/promises'));
 vi.mock(import('node:os'));
-
-vi.mock('@podman-desktop/api', () => ({
-  Disposable: {
-    create: (fn: () => void): Disposable => ({ dispose: fn }),
-  },
-  CancellationTokenSource: vi.fn(),
-}));
 
 const extensionsMock: typeof extensions = {
   getExtension: vi.fn(),

--- a/packages/backend/src/services/quadlet-service.spec.ts
+++ b/packages/backend/src/services/quadlet-service.spec.ts
@@ -40,11 +40,6 @@ import { QuadletType } from '/@shared/src/utils/quadlet-type';
 
 vi.mock('../utils/parsers/quadlet-dryrun-parser');
 vi.mock('../utils/parsers/quadlet-type-parser');
-vi.mock('@podman-desktop/api', () => ({
-  ProgressLocation: {
-    TASK_WIDGET: 2,
-  },
-}));
 
 const WSL_RUNNING_PROVIDER_CONNECTION_MOCK: ProviderContainerConnection = {
   connection: {

--- a/packages/backend/src/services/webview-service.spec.ts
+++ b/packages/backend/src/services/webview-service.spec.ts
@@ -9,12 +9,6 @@ import { readFile } from 'node:fs/promises';
 
 vi.mock(import('node:fs/promises'));
 
-vi.mock('@podman-desktop/api', () => ({
-  Uri: {
-    joinPath: vi.fn(),
-  },
-}));
-
 const windowMock: typeof windowsApi = {
   createWebviewPanel: vi.fn(),
 } as unknown as typeof windowsApi;

--- a/packages/backend/src/utils/logger-impl.spec.ts
+++ b/packages/backend/src/utils/logger-impl.spec.ts
@@ -34,10 +34,6 @@ const CANCELLATION_TOKEN_SOURCE_MOCK: CancellationTokenSource = {
   dispose: vi.fn(),
 } as unknown as CancellationTokenSource;
 
-vi.mock('@podman-desktop/api', () => ({
-  CancellationTokenSource: vi.fn(),
-}));
-
 beforeEach(() => {
   vi.resetAllMocks();
   vi.mocked(CancellationTokenSource).mockReturnValue(CANCELLATION_TOKEN_SOURCE_MOCK);

--- a/packages/backend/tsconfig.json
+++ b/packages/backend/tsconfig.json
@@ -17,6 +17,6 @@
     "noImplicitReturns": true,
     "noUnusedLocals": true
   },
-  "include": ["src", "types/*.d.ts", "../../types/*.d.ts", "../shared/*.ts", "../shared/**/*.ts"],
+  "include": ["src", "vitest.setup.*", "types/*.d.ts", "../../types/*.d.ts", "../shared/*.ts", "../shared/**/*.ts"],
   "exclude": ["vite.config.ts", "vitest.config.ts"]
 }

--- a/packages/backend/vitest.config.ts
+++ b/packages/backend/vitest.config.ts
@@ -26,7 +26,7 @@ export default defineProject({
   test: {
     globals: true,
     environment: 'node',
-    include: ['src/**/*.{test,spec}.?(c|m)[jt]s?(x)'],
+    include: ['src/**/*.{test,spec}.?(c|m)[jt]s?(x)', 'vitest.setup.spec.ts'],
     alias: {
       '@podman-desktop/api': resolve(WORKSPACE_ROOT, '__mocks__/@podman-desktop/api.js'),
       '/@/': join(PACKAGE_ROOT, 'src') + '/',

--- a/packages/backend/vitest.config.ts
+++ b/packages/backend/vitest.config.ts
@@ -33,5 +33,6 @@ export default defineProject({
       '/@gen/': join(PACKAGE_ROOT, 'src-generated') + '/',
       '/@shared/': join(PACKAGE_ROOT, '../shared') + '/',
     },
+    setupFiles: ['./vitest.setup.ts'],
   },
 });

--- a/packages/backend/vitest.setup.spec.ts
+++ b/packages/backend/vitest.setup.spec.ts
@@ -1,0 +1,87 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { vi, describe, test, expect } from 'vitest';
+import { EventEmitter, Disposable } from '@podman-desktop/api';
+
+describe('EventEmitter', () => {
+  test('EventEmitter#event should register listener', () => {
+    const emitter = new EventEmitter<string>();
+    const listener = vi.fn();
+
+    // register listener
+    emitter.event(listener);
+    // emit
+    emitter.fire('potatoes');
+    // ensure expected behaviour
+    expect(listener).toHaveBeenCalledOnce();
+    expect(listener).toHaveBeenCalledWith('potatoes');
+  });
+
+  test('EventEmitter#event should provide a disposable', () => {
+    const emitter = new EventEmitter<string>();
+    const listener = vi.fn();
+
+    // register listener
+    const disposable = emitter.event(listener);
+    disposable.dispose();
+    // emit
+    emitter.fire('potatoes');
+    // ensure expected behaviour
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  test('EventEmitter#dispose should dispose all listeners', () => {
+    const emitter = new EventEmitter<string>();
+    const listener = vi.fn();
+
+    // register listener
+    emitter.event(listener);
+    emitter.dispose();
+    // emit
+    emitter.fire('potatoes');
+    // ensure expected behaviour
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  test('EventEmitter#event should support multiple listeners', () => {
+    const emitter = new EventEmitter<string>();
+    const listeners = Array.from({ length: 10 }).map(() => vi.fn());
+
+    // register listeners
+    listeners.forEach(listener => emitter.event(listener));
+
+    // emit
+    emitter.fire('potatoes');
+    // ensure expected behaviour
+    listeners.forEach(listener => {
+      expect(listener).toHaveBeenCalledOnce();
+      expect(listener).toHaveBeenCalledWith('potatoes');
+    });
+  });
+});
+
+describe('Disposable', () => {
+  test('Disposable#create should create disposable from function', () => {
+    const callback = vi.fn();
+    const disposable = Disposable.create(callback);
+    disposable.dispose();
+
+    expect(callback).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/backend/vitest.setup.ts
+++ b/packages/backend/vitest.setup.ts
@@ -1,0 +1,60 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { vi } from 'vitest';
+import type { Event, EventEmitter, Disposable } from '@podman-desktop/api';
+
+/**
+ * Mock the {@link EventEmitter} class logic
+ */
+class EventEmitterMock<T> implements EventEmitter<T> {
+  #set: Set<(t: T) => void> = new Set();
+
+  get event(): Event<T> {
+    return listener => {
+      this.#set.add(listener);
+      return {
+        dispose: (): void => {
+          this.#set.delete(listener);
+        },
+      };
+    };
+  }
+
+  fire(data: T): void {
+    this.#set.forEach(listener => listener(data));
+  }
+
+  dispose(): void {
+    this.#set.clear();
+  }
+}
+
+vi.mock('@podman-desktop/api', () => ({
+  EventEmitter: EventEmitterMock,
+  ProgressLocation: {
+    TASK_WIDGET: 2,
+  },
+  Disposable: {
+    create: (fn: () => void): Disposable => ({ dispose: fn }),
+  },
+  CancellationTokenSource: vi.fn(),
+  Uri: {
+    joinPath: vi.fn(),
+  },
+}));


### PR DESCRIPTION
## Description

In the `packages/backend/**.spec.ts` files the `@podman-desktop/api` is often mocked the same way. Let's create a dedicated `vitest.setup.ts` doing the mocking of what we need.

## Testing

- [x] unit tests has been added