### PR TITLE
feat(backend): make Publisher uses EventEmitter

### DIFF
--- a/packages/backend/src/services/provider-service.ts
+++ b/packages/backend/src/services/provider-service.ts
@@ -23,7 +23,8 @@ export class ProviderService
     super(dependencies.webview, Messages.UPDATE_PROVIDERS, () => this.all());
   }
 
-  dispose(): void {
+  override dispose(): void {
+    super.dispose();
     this.#disposables.forEach((disposable: Disposable) => disposable.dispose());
   }
 

--- a/packages/backend/src/services/quadlet-service.ts
+++ b/packages/backend/src/services/quadlet-service.ts
@@ -465,7 +465,8 @@ export class QuadletService extends QuadletHelper implements Disposable, AsyncIn
     }
   }
 
-  dispose(): void {
+  override dispose(): void {
+    super.dispose();
     this.#value.clear();
     this.#extensionsEventDisposable?.dispose();
     this.#extensionsEventDisposable = undefined;

--- a/packages/backend/src/services/routing-service.ts
+++ b/packages/backend/src/services/routing-service.ts
@@ -57,7 +57,8 @@ export class RoutingService extends Publisher<string | undefined> implements Dis
     return this.write(`/quadlets/generate?${search.toString()}`);
   }
 
-  dispose(): void {
+  override dispose(): void {
+    super.dispose();
     this.#route = undefined;
   }
 }

--- a/packages/backend/src/utils/publisher.spec.ts
+++ b/packages/backend/src/utils/publisher.spec.ts
@@ -31,11 +31,7 @@ beforeEach(() => {
 
 test('ensure publisher properly use getter', async () => {
   const getterMock = vi.fn().mockReturnValue('dummyValue');
-  const publisher = new Publisher<string>(
-    WEBVIEW_MOCK,
-    Messages.TEST_PURPOSE,
-    getterMock,
-  );
+  const publisher = new Publisher<string>(WEBVIEW_MOCK, Messages.TEST_PURPOSE, getterMock);
   publisher.notify();
 
   await vi.waitFor(() => {
@@ -49,19 +45,15 @@ test('ensure publisher properly use getter', async () => {
 
 test('publisher should notify all listeners', async () => {
   const getterMock = vi.fn().mockReturnValue('dummyValue');
-  const publisher = new Publisher<string>(
-    WEBVIEW_MOCK,
-    Messages.TEST_PURPOSE,
-    getterMock,
-  );
+  const publisher = new Publisher<string>(WEBVIEW_MOCK, Messages.TEST_PURPOSE, getterMock);
 
-  const listeners = Array.from({length: 10}).map(() => vi.fn());
-  listeners.forEach((listener) => publisher.event(listener));
+  const listeners = Array.from({ length: 10 }).map(() => vi.fn());
+  listeners.forEach(listener => publisher.event(listener));
 
   publisher.notify();
 
   await vi.waitFor(() => {
-    listeners.forEach((listener) => {
+    listeners.forEach(listener => {
       expect(listener).toHaveBeenCalledOnce();
       expect(listener).toHaveBeenCalledWith('dummyValue');
     });

--- a/packages/backend/src/utils/publisher.ts
+++ b/packages/backend/src/utils/publisher.ts
@@ -15,25 +15,40 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
-import type { Webview } from '@podman-desktop/api';
+import type { Event, Webview, Disposable } from '@podman-desktop/api';
+import { EventEmitter } from '@podman-desktop/api';
 import type { Messages } from '/@shared/src/messages';
 
-export class Publisher<T> {
+export class Publisher<T> implements Disposable {
+  private readonly _onEvent = new EventEmitter<T>();
+  readonly event: Event<T> = this._onEvent.event;
+
   constructor(
     private webview: Webview,
     private channel: Messages,
     private getter: () => T,
-  ) {}
+  ) {
+    // register the webview#postMessage logic
+    this.event(this.postMessage.bind(this));
+  }
 
-  notify(): void {
+  protected postMessage(content: T): void {
     // side-case: the notify function may be called during the constructor so this may be undefined.
     this?.webview
       .postMessage({
         id: this.channel,
-        body: this.getter(),
+        body: content,
       })
       .catch((err: unknown) => {
         console.error(`Something went wrong while emitting ${this.channel}: ${String(err)}`);
       });
+  }
+
+  notify(): void {
+    this._onEvent.fire(this.getter());
+  }
+
+  dispose(): void {
+    this._onEvent.dispose();
   }
 }


### PR DESCRIPTION
## Description

The `Publisher` class notify the webview with content provided by the class extending it; however in some cases other class may want to be notified, not only the webview.

For example, in https://github.com/podman-desktop/extension-podman-quadlet/pull/535 the `PodmanService` need to refresh its cache if any provider changes: it should listener for the `ProviderService` event.

## Testing

- [x] unit tests has been added