### PR TITLE
feat(backend): create `PodmanSFTP` client

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -67,6 +67,7 @@
     "@podman-desktop/podman-extension-api": "^1.18.0",
     "@types/node": "^22",
     "@types/ssh2": "^1.15.5",
+    "@types/ssh2-sftp-client": "^9.0.4",
     "@vitest/coverage-v8": "^3.0.9",
     "prettier": "^3.5.3",
     "typescript": "5.8.3",
@@ -79,6 +80,7 @@
     "semver": "^7.7.1",
     "js-yaml": "^4.1.0",
     "podlet-js": "workspace:^",
-    "ssh2": "^1.16.0"
+    "ssh2": "^1.16.0",
+    "ssh2-sftp-client": "^12.0.0"
   }
 }

--- a/packages/backend/src/utils/remote/podman-sftp.spec.ts
+++ b/packages/backend/src/utils/remote/podman-sftp.spec.ts
@@ -1,0 +1,161 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import { vi, test, expect, beforeEach, describe, assert } from 'vitest';
+import type { ConnectConfig } from 'ssh2';
+import SftpClient from 'ssh2-sftp-client';
+import { PodmanSFTP } from './podman-sftp';
+
+vi.mock(import('ssh2'));
+vi.mock(import('ssh2-sftp-client'));
+
+const SSH_CONFIG_MOCK: ConnectConfig = {
+  host: 'localhost',
+  port: 2222,
+  username: 'potatoes',
+  privateKey: '==content==',
+};
+
+const SFTP_CLIENT_MOCK: SftpClient = {
+  connect: vi.fn(),
+  on: vi.fn(),
+  end: vi.fn(),
+  get: vi.fn(),
+  delete: vi.fn(),
+  mkdir: vi.fn(),
+  put: vi.fn(),
+} as unknown as SftpClient;
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.mocked(SFTP_CLIENT_MOCK.end).mockResolvedValue(undefined);
+
+  vi.mocked(SftpClient).mockReturnValue(SFTP_CLIENT_MOCK);
+});
+
+describe('connect', () => {
+  let podmanSFTP: PodmanSFTP;
+
+  beforeEach(() => {
+    podmanSFTP = new PodmanSFTP(SSH_CONFIG_MOCK);
+  });
+
+  test('connection successful', async () => {
+    await podmanSFTP.connect();
+
+    expect(SFTP_CLIENT_MOCK.connect).toHaveBeenCalledWith(SSH_CONFIG_MOCK);
+    expect(podmanSFTP.connected).toBeTruthy();
+  });
+});
+
+describe('read', () => {
+  let podmanSFTP: PodmanSFTP;
+
+  beforeEach(async () => {
+    podmanSFTP = new PodmanSFTP(SSH_CONFIG_MOCK);
+    await podmanSFTP.connect();
+  });
+
+  test('get buffer response should be converted to utf-8 string', async () => {
+    // mock buffer for resolve content
+    vi.mocked(SFTP_CLIENT_MOCK.get).mockResolvedValue(Buffer.from('bar'));
+
+    const response: string = await podmanSFTP.read('/foo');
+    expect(response).toBe('bar');
+  });
+
+  test('get string should be returned as it is', async () => {
+    // mock string for resolve content
+    vi.mocked(SFTP_CLIENT_MOCK.get).mockResolvedValue('bar');
+
+    const response: string = await podmanSFTP.read('/foo');
+    expect(response).toBe('bar');
+  });
+
+  test('homedir path should be resolved', async () => {
+    // mock string for resolve content
+    vi.mocked(SFTP_CLIENT_MOCK.get).mockResolvedValue('bar');
+
+    await podmanSFTP.read('~/foo');
+
+    expect(SFTP_CLIENT_MOCK.get).toHaveBeenCalledWith(`/home/${SSH_CONFIG_MOCK.username}/foo`);
+  });
+});
+
+describe('write', () => {
+  let podmanSFTP: PodmanSFTP;
+
+  beforeEach(async () => {
+    podmanSFTP = new PodmanSFTP(SSH_CONFIG_MOCK);
+    await podmanSFTP.connect();
+  });
+
+  test('should mkdir parent', async () => {
+    await podmanSFTP.write('/foo/bar.txt', 'hello');
+
+    expect(SFTP_CLIENT_MOCK.mkdir).toHaveBeenCalledWith('/foo', true);
+    expect(SFTP_CLIENT_MOCK.put).toHaveBeenCalledWith(expect.any(Buffer), '/foo/bar.txt');
+  });
+
+  test('content should be converted to buffer', async () => {
+    await podmanSFTP.write('/foo/bar.txt', 'hello');
+
+    expect(SFTP_CLIENT_MOCK.put).toHaveBeenCalledWith(expect.any(Buffer), '/foo/bar.txt');
+    const buffer = vi.mocked(SFTP_CLIENT_MOCK.put).mock.calls[0][0];
+    assert(Buffer.isBuffer(buffer), 'first argument should be a buffer');
+
+    expect(buffer.toString('utf-8')).toStrictEqual('hello');
+  });
+
+  test('homedir path should be resolved', async () => {
+    await podmanSFTP.write('~/foo/bar.txt', 'hello');
+
+    expect(SFTP_CLIENT_MOCK.mkdir).toHaveBeenCalledWith(`/home/${SSH_CONFIG_MOCK.username}/foo`, true);
+    expect(SFTP_CLIENT_MOCK.put).toHaveBeenCalledWith(
+      expect.any(Buffer),
+      `/home/${SSH_CONFIG_MOCK.username}/foo/bar.txt`,
+    );
+  });
+});
+
+describe('rm', () => {
+  let podmanSFTP: PodmanSFTP;
+
+  beforeEach(async () => {
+    podmanSFTP = new PodmanSFTP(SSH_CONFIG_MOCK);
+    await podmanSFTP.connect();
+  });
+
+  test('absolute path should be kept as it is', async () => {
+    await podmanSFTP.rm('/foo/bar.txt');
+
+    expect(SFTP_CLIENT_MOCK.delete).toHaveBeenCalledWith(`/foo/bar.txt`);
+  });
+
+  test('homedir path should be resolved', async () => {
+    await podmanSFTP.rm('~/foo/bar.txt');
+
+    expect(SFTP_CLIENT_MOCK.delete).toHaveBeenCalledWith(`/home/${SSH_CONFIG_MOCK.username}/foo/bar.txt`);
+  });
+});
+
+test('dispose should end ssh2 client', () => {
+  const podmanSFTP = new PodmanSFTP(SSH_CONFIG_MOCK);
+  podmanSFTP.dispose();
+
+  expect(SFTP_CLIENT_MOCK.end).toHaveBeenCalledOnce();
+});

--- a/packages/backend/src/utils/remote/podman-sftp.ts
+++ b/packages/backend/src/utils/remote/podman-sftp.ts
@@ -1,0 +1,82 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import type { Disposable } from '@podman-desktop/api';
+import type { ConnectConfig } from 'ssh2';
+import SftpClient from 'ssh2-sftp-client';
+import { dirname } from 'node:path/posix';
+
+export class PodmanSFTP implements Disposable {
+  #sshConfig: ConnectConfig;
+  #client: SftpClient;
+  #connected: boolean = false;
+
+  constructor(sshConfig: ConnectConfig) {
+    this.#sshConfig = sshConfig;
+    this.#client = new SftpClient();
+  }
+
+  dispose(): void {
+    this.#client.end().catch(console.error);
+  }
+
+  get connected(): boolean {
+    return this.#connected;
+  }
+
+  async connect(): Promise<void> {
+    try {
+      await this.#client.connect(this.#sshConfig);
+      this.#connected = true;
+    } catch (err: unknown) {
+      console.error('Something went wrong while trying to connect to podman connection', err);
+    }
+
+    this.#client.on('error', () => {
+      this.#connected = false;
+    });
+  }
+
+  protected resolve(path: string): string {
+    return path.replace('~', `/home/${this.#sshConfig.username}`);
+  }
+
+  async read(path: string): Promise<string> {
+    const response = await this.#client.get(this.resolve(path));
+
+    if (Buffer.isBuffer(response)) {
+      return response.toString('utf8');
+    }
+
+    if (typeof response !== 'string') throw new Error('PodmanSFTP read operation cannot handle writable stream');
+    return response;
+  }
+
+  async write(destination: string, content: string): Promise<void> {
+    // resolve path (replace ~ with /home/{username}
+    const resolved = this.resolve(destination);
+
+    // create parent directory
+    await this.#client.mkdir(dirname(resolved), true);
+    // put the file
+    await this.#client.put(Buffer.from(content, 'utf8'), resolved);
+  }
+
+  async rm(path: string): Promise<void> {
+    await this.#client.delete(this.resolve(path));
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,9 @@ importers:
       ssh2:
         specifier: ^1.16.0
         version: 1.16.0
+      ssh2-sftp-client:
+        specifier: ^12.0.0
+        version: 12.0.0
     devDependencies:
       '@podman-desktop/api':
         specifier: ^1.18.0
@@ -127,6 +130,9 @@ importers:
       '@types/ssh2':
         specifier: ^1.15.5
         version: 1.15.5
+      '@types/ssh2-sftp-client':
+        specifier: ^9.0.4
+        version: 9.0.4
       '@vitest/coverage-v8':
         specifier: ^3.0.9
         version: 3.0.9(vitest@3.0.9(@types/node@22.13.10)(jiti@2.4.2)(jsdom@26.1.0)(lightningcss@1.29.2)(yaml@2.6.1))
@@ -1133,6 +1139,9 @@ packages:
   '@types/semver@7.5.8':
     resolution: {integrity: sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==}
 
+  '@types/ssh2-sftp-client@9.0.4':
+    resolution: {integrity: sha512-gnIn56MTB9W3A3hPL/1sHI23t8YwcE3eVYa1O2XjT9vaqimFdtNHxyQiy5Y78+ociQTKazMSD8YyMEO4QjNMrg==}
+
   '@types/ssh2@1.15.5':
     resolution: {integrity: sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ==}
 
@@ -1590,6 +1599,9 @@ packages:
   buffer-crc32@0.2.13:
     resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
 
+  buffer-from@1.1.2:
+    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
   buildcheck@0.0.6:
     resolution: {integrity: sha512-8f9ZJCUXyT1M35Jx7MkBgmBMo3oHTTBIPLiY9xyL0pl3T5RwcPEY8cUHr5LBNfu/fk6c2T4DJZuVM/8ZZT2D2A==}
     engines: {node: '>=10.0.0'}
@@ -1702,6 +1714,10 @@ packages:
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  concat-stream@2.0.0:
+    resolution: {integrity: sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==}
+    engines: {'0': node >= 6.0}
 
   concurrently@9.1.2:
     resolution: {integrity: sha512-H9MWcoPsYddwbOGM6difjVwVZHl63nwMEwDJG/L7VGtuaJhb12h2caPG2tVPWs7emuYix252iGfqOyrz1GczTQ==}
@@ -3317,6 +3333,10 @@ packages:
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
+
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
@@ -3559,6 +3579,10 @@ packages:
   sprintf-js@1.1.3:
     resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
 
+  ssh2-sftp-client@12.0.0:
+    resolution: {integrity: sha512-k+ocDsx6N2eDwQlIRwJFa0I1bkQpFPhIc+cv1iplaQaIPXFt9YM1ZnXCJOW4OILS5dzE+12OlhYIF5g0AzgVfg==}
+    engines: {node: '>=18.20.4'}
+
   ssh2@1.16.0:
     resolution: {integrity: sha512-r1X4KsBGedJqo7h8F5c4Ybpcr5RjyP+aWIG007uBPRjmdQWfEiVLzSK71Zji1B9sKxwaCvD8y8cwSkYrlLiRRg==}
     engines: {node: '>=10.16.0'}
@@ -3602,6 +3626,9 @@ packages:
   string.prototype.trimstart@1.0.8:
     resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
     engines: {node: '>= 0.4'}
+
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
@@ -3859,6 +3886,9 @@ packages:
   typed-array-length@1.0.7:
     resolution: {integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==}
     engines: {node: '>= 0.4'}
+
+  typedarray@0.0.6:
+    resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
 
   typescript-eslint@8.32.0:
     resolution: {integrity: sha512-UMq2kxdXCzinFFPsXc9o2ozIpYCCOiEC46MG3yEh5Vipq6BO27otTtEBZA1fQ66DulEUgE97ucQ/3YY66CPg0A==}
@@ -4962,6 +4992,10 @@ snapshots:
 
   '@types/semver@7.5.8': {}
 
+  '@types/ssh2-sftp-client@9.0.4':
+    dependencies:
+      '@types/ssh2': 1.15.5
+
   '@types/ssh2@1.15.5':
     dependencies:
       '@types/node': 18.19.87
@@ -5522,6 +5556,8 @@ snapshots:
 
   buffer-crc32@0.2.13: {}
 
+  buffer-from@1.1.2: {}
+
   buildcheck@0.0.6:
     optional: true
 
@@ -5635,6 +5671,13 @@ snapshots:
   compose-spec-ts@0.3.2: {}
 
   concat-map@0.0.1: {}
+
+  concat-stream@2.0.0:
+    dependencies:
+      buffer-from: 1.1.2
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+      typedarray: 0.0.6
 
   concurrently@9.1.2:
     dependencies:
@@ -7425,6 +7468,12 @@ snapshots:
 
   react-is@17.0.2: {}
 
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+
   readdirp@4.1.2: {}
 
   redent@3.0.0:
@@ -7745,6 +7794,11 @@ snapshots:
   sprintf-js@1.1.3:
     optional: true
 
+  ssh2-sftp-client@12.0.0:
+    dependencies:
+      concat-stream: 2.0.0
+      ssh2: 1.16.0
+
   ssh2@1.16.0:
     dependencies:
       asn1: 0.2.6
@@ -7804,6 +7858,10 @@ snapshots:
       call-bind: 1.0.7
       define-properties: 1.2.1
       es-object-atoms: 1.0.0
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
 
   strip-ansi@6.0.1:
     dependencies:
@@ -8062,6 +8120,8 @@ snapshots:
       is-typed-array: 1.1.13
       possible-typed-array-names: 1.0.0
       reflect.getprototypeof: 1.0.7
+
+  typedarray@0.0.6: {}
 
   typescript-eslint@8.32.0(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3):
     dependencies:


### PR DESCRIPTION
## Description

Very similar to https://github.com/podman-desktop/extension-podman-quadlet/pull/545 the PodmanSFTP (Or Podman Secure File Transfer Protocol) is a handy class allowing us to interact with the filesystem of a podman machine.

The Quadlet extension need to `read`, `write` files inside the Podman Machine, currently it is **super hacky**, I used `podman machine ssh <connection> cat <path>` to read file from stdout.

This is not really nice, and there are alternative. Podman always come with an ssh connection to the machines, and we can use that to establish a secure file transfer protocol between the machine and us.  

The amazing [ssh2-sftp-client](https://www.npmjs.com/package/ssh2-sftp-client) package based on `ssh2` allow us to do that.

## Related issues

Required https://github.com/podman-desktop/extension-podman-quadlet/issues/515

## Testing

- [x] unit tests has been added