### PR TITLE
feat(backend): create PodmanWorker abstract class

### DIFF
--- a/packages/backend/src/utils/worker/podman-worker.ts
+++ b/packages/backend/src/utils/worker/podman-worker.ts
@@ -1,0 +1,125 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import type {
+  CancellationToken,
+  Logger,
+  RunResult,
+  Disposable,
+  ProviderContainerConnection,
+  RunError,
+} from '@podman-desktop/api';
+import type { AsyncInit } from '../async-init';
+import { isRunError } from '../run-error';
+
+export abstract class PodmanWorker implements Disposable, AsyncInit {
+  constructor(protected connection: ProviderContainerConnection) {}
+
+  /**
+   * Return the content of the file at path
+   * @param path
+   */
+  abstract read(path: string): Promise<string>;
+
+  /**
+   * Remove a file at a given path
+   * @remarks does not support recursive
+   * @param path
+   */
+  abstract rm(path: string): Promise<void>;
+
+  /**
+   * Write content to the path given
+   * @remarks mkdir -r the parent directory when called
+   * @param path
+   * @param content
+   */
+  abstract write(path: string, content: string): Promise<void>;
+
+  /**
+   * execute the given command to the
+   * @param command
+   * @param options
+   */
+  abstract exec(
+    command: string,
+    options: {
+      args: string[];
+      logger?: Logger;
+      token?: CancellationToken;
+      env?: Record<string, string>;
+    },
+  ): Promise<RunResult>;
+
+  /**
+   * systemctl has a weird specificity to change the return code depending on the status.
+   * | value   | Description in LSB                             | Use in systemd                     |
+   * | :------ | :--------------------------------------------  | :--------------------------------- |
+   * | 0       | program is running or service is OK            | unit is active                     |
+   * | 1       | program is dead and /var/run pid file exists   | unit not failed (used by is-failed)|
+   * | 2       | program is dead and /var/lock lock file exists | unused                             |
+   * | 3       | program is not running                         | unit is not active                 |
+   * | 4       | program or service status is unknown           | no such unit                       |
+   *
+   * ref {@link https://www.freedesktop.org/software/systemd/man/latest/systemctl.html#Exit%20status}
+   *
+   * @privateRemarks We do not expose {@link executeWrapper} for security purpose, so we must expose the systemctl exec
+   *
+   * @dangerous
+   * @param options
+   */
+  async systemctlExec(options: {
+    args: string[];
+    logger?: Logger;
+    token?: CancellationToken;
+    env?: Record<string, string>;
+  }): Promise<RunResult | RunError> {
+    return this.exec('systemctl', options).catch((err: unknown) => {
+      // check err is an RunError
+      if (isRunError(err)) return err;
+      throw err;
+    });
+  }
+
+  async quadletExec(options: {
+    args: string[];
+    logger?: Logger;
+    token?: CancellationToken;
+    env?: Record<string, string>;
+  }): Promise<RunResult> {
+    return this.exec('/usr/libexec/podman/quadlet', options);
+  }
+
+  async journalctlExec(options: {
+    args: string[];
+    logger?: Logger;
+    token?: CancellationToken;
+    env?: Record<string, string>;
+  }): Promise<RunResult> {
+    return this.exec('journalctl', options);
+  }
+
+  /**
+   * Dispose any pending resources / connections
+   */
+  abstract dispose(): void;
+
+  /**
+   * Async init the worker
+   */
+  abstract init(): Promise<void>;
+}

--- a/packages/backend/src/utils/worker/podman-worker.ts
+++ b/packages/backend/src/utils/worker/podman-worker.ts
@@ -57,8 +57,8 @@ export abstract class PodmanWorker implements Disposable, AsyncInit {
    */
   abstract exec(
     command: string,
-    options: {
-      args: string[];
+    options?: {
+      args?: string[];
       logger?: Logger;
       token?: CancellationToken;
       env?: Record<string, string>;
@@ -95,6 +95,10 @@ export abstract class PodmanWorker implements Disposable, AsyncInit {
     });
   }
 
+  /**
+   * Execute the `quadlet` command on the podman connection
+   * @param options the options for the exec logic
+   */
   async quadletExec(options: {
     args: string[];
     logger?: Logger;
@@ -104,6 +108,10 @@ export abstract class PodmanWorker implements Disposable, AsyncInit {
     return this.exec('/usr/libexec/podman/quadlet', options);
   }
 
+  /**
+   * Execute the `journalctl` command on the podman connection
+   * @param options the options for the exec logic
+   */
   async journalctlExec(options: {
     args: string[];
     logger?: Logger;


### PR DESCRIPTION
## Description

`PodmanWorker` is an abstract class with several method; `read`, `write`, `exec` and other handy methods. When dealing a podman connection (either native or remote) the goal is to use a worker instead of the methods in `PodmanService`.

We will have two implementation of PodmanWorker:
- `PodmanNativeWorker`: on linux deals with native podman
- `PodmanSSHWorker`: deals with Podman Machines and remote through SSH

Having such abstract logic allow us to simplify the code, and reduce coupling. 

## Related issues

Required https://github.com/podman-desktop/extension-podman-quadlet/issues/515
