### PR TITLE
feat(backend): adding getPodmanConnections logic

### DIFF
--- a/packages/backend/src/models/podman-connection.ts
+++ b/packages/backend/src/models/podman-connection.ts
@@ -1,0 +1,30 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/**
+ * This interface represent the item in the array we get when
+ * running `podman system connection ls --format=json`
+ */
+export interface PodmanConnection {
+  Name: string;
+  IsMachine?: boolean;
+  URI: string;
+  Identity?: string;
+  Default: boolean;
+  ReadWrite: boolean;
+}


### PR DESCRIPTION
## Description

Following https://github.com/podman-desktop/extension-podman-quadlet/pull/547, https://github.com/podman-desktop/extension-podman-quadlet/pull/546, https://github.com/podman-desktop/extension-podman-quadlet/pull/545, and to continue the work required for https://github.com/podman-desktop/extension-podman-quadlet/issues/515 (mostly splitting https://github.com/podman-desktop/extension-podman-quadlet/pull/535).

Adding the `getPodmanConnections` function, which use the [@podman-desktop/podman-extension-api](https://www.npmjs.com/package/@podman-desktop/podman-extension-api) to exec `podman system connection ls`.

## Testing

- [x] unit tests has been added
