### PR TITLE
feat(backend): adding native podman worker

### DIFF
--- a/packages/backend/src/utils/worker/podman-native-worker.spec.ts
+++ b/packages/backend/src/utils/worker/podman-native-worker.spec.ts
@@ -1,0 +1,134 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { PodmanNativeWorker } from './podman-native-worker';
+import { homedir } from 'node:os';
+import { readFile, rm, mkdir, writeFile } from 'node:fs/promises';
+import { dirname } from 'node:path/posix';
+import type { process as ProcessApi, ProviderContainerConnection } from '@podman-desktop/api';
+import type { PodmanWorker } from './podman-worker';
+
+// mock node packages
+vi.mock('node:fs/promises');
+vi.mock('node:os');
+
+const WSL_PROVIDER_CONNECTION_MOCK: ProviderContainerConnection = {
+  connection: {
+    type: 'podman',
+    vmType: 'WSL',
+    name: 'podman-machine-default',
+  },
+  providerId: 'podman',
+} as ProviderContainerConnection;
+
+const NATIVE_PROVIDER_CONNECTION_MOCK: ProviderContainerConnection = {
+  connection: {
+    type: 'podman',
+    vmType: undefined,
+    name: 'podman',
+  },
+  providerId: 'podman',
+} as ProviderContainerConnection;
+
+const PROCESS_API_MOCK: typeof ProcessApi = {
+  exec: vi.fn(),
+} as unknown as typeof ProcessApi;
+
+const HOMEDIR_MOCK: string = '/home';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+
+  vi.mocked(homedir).mockReturnValue(HOMEDIR_MOCK);
+});
+
+describe('init', () => {
+  test('should initialize successfully when vmType is undefined', async () => {
+    const worker = new PodmanNativeWorker(NATIVE_PROVIDER_CONNECTION_MOCK, PROCESS_API_MOCK);
+    await expect(worker.init()).resolves.toBeUndefined();
+  });
+
+  test('should throw error when vmType is defined', async () => {
+    const worker = new PodmanNativeWorker(WSL_PROVIDER_CONNECTION_MOCK, PROCESS_API_MOCK);
+    await expect(worker.init()).rejects.toThrow('PodmanNativeWorker cannot deal with podman machines');
+  });
+});
+
+describe('read', () => {
+  test('should read file content', async () => {
+    const worker = new PodmanNativeWorker(NATIVE_PROVIDER_CONNECTION_MOCK, PROCESS_API_MOCK);
+
+    const expectedContent = 'file content';
+    vi.mocked(readFile).mockResolvedValue(expectedContent);
+
+    const content = await worker.read('test-path');
+
+    expect(content).toBe(expectedContent);
+    expect(readFile).toHaveBeenCalledWith('test-path', { encoding: 'utf8' });
+  });
+});
+
+describe('write', () => {
+  let worker: PodmanWorker;
+  beforeEach(() => {
+    worker = new PodmanNativeWorker(NATIVE_PROVIDER_CONNECTION_MOCK, PROCESS_API_MOCK);
+  });
+
+  test('path with tilde should be resolved', async () => {
+    await worker.write('~/hello/world.txt', 'foo');
+
+    const resolved = `${HOMEDIR_MOCK}/hello/world.txt`;
+    expect(mkdir).toHaveBeenCalledWith(dirname(resolved), { recursive: true });
+    expect(writeFile).toHaveBeenCalledWith(resolved, 'foo', { encoding: 'utf8' });
+  });
+
+  test('absolute path should be used as it is', async () => {
+    await worker.write('/hello/world.txt', 'foo');
+
+    expect(mkdir).toHaveBeenCalledWith('/hello', { recursive: true });
+    expect(writeFile).toHaveBeenCalledWith('/hello/world.txt', 'foo', { encoding: 'utf8' });
+  });
+});
+
+describe('rm', () => {
+  test('should remove file', async () => {
+    const worker = new PodmanNativeWorker(NATIVE_PROVIDER_CONNECTION_MOCK, PROCESS_API_MOCK);
+
+    const testPath = 'test-path';
+
+    await worker.rm(testPath);
+
+    expect(rm).toHaveBeenCalledWith(testPath, { recursive: false, force: false });
+  });
+});
+
+describe('exec', () => {
+  let worker: PodmanWorker;
+  beforeEach(() => {
+    worker = new PodmanNativeWorker(NATIVE_PROVIDER_CONNECTION_MOCK, PROCESS_API_MOCK);
+  });
+
+  test('should execute command with options', async () => {
+    await worker.exec('echo', {
+      args: ['hello world'],
+    });
+
+    expect(PROCESS_API_MOCK.exec).toHaveBeenCalledWith('echo', ['hello world'], {});
+  });
+});

--- a/packages/backend/src/utils/worker/podman-native-worker.ts
+++ b/packages/backend/src/utils/worker/podman-native-worker.ts
@@ -1,0 +1,76 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import type {
+  Logger,
+  CancellationToken,
+  RunResult,
+  ProviderContainerConnection,
+  process as ProcessApi,
+} from '@podman-desktop/api';
+import { PodmanWorker } from './podman-worker';
+import { homedir } from 'node:os';
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { dirname } from 'node:path/posix';
+
+export class PodmanNativeWorker extends PodmanWorker {
+  constructor(
+    connection: ProviderContainerConnection,
+    protected processApi: typeof ProcessApi,
+  ) {
+    super(connection);
+  }
+
+  override read(path: string): Promise<string> {
+    return readFile(path, { encoding: 'utf8' });
+  }
+
+  override rm(path: string): Promise<void> {
+    return rm(path, { recursive: false, force: false });
+  }
+
+  override async write(path: string, content: string): Promise<void> {
+    // 1. resolve homedir
+    const resolved = path.replace('~', homedir());
+    // 2. mkdir parent directory
+    await mkdir(dirname(resolved), { recursive: true });
+    // 3. write file
+    await writeFile(resolved, content, { encoding: 'utf8' });
+  }
+
+  override exec(
+    command: string,
+    options?: {
+      args?: string[];
+      logger?: Logger;
+      token?: CancellationToken;
+      env?: Record<string, string>;
+    },
+  ): Promise<RunResult> {
+    return this.processApi.exec(command, options?.args, {
+      logger: options?.logger,
+      env: options?.env,
+      token: options?.token,
+    });
+  }
+
+  override dispose(): void {}
+
+  override async init(): Promise<void> {
+    if (this.connection.connection.vmType) throw new Error('PodmanNativeWorker cannot deal with podman machines');
+  }
+}


### PR DESCRIPTION
## Description

Following (https://github.com/podman-desktop/extension-podman-quadlet/pull/547) adding `PodmanWorker` abstract class, here is the first implementation, the `PodmanNativeWorker`.

This PR is a part of https://github.com/podman-desktop/extension-podman-quadlet/pull/535 and is required for https://github.com/podman-desktop/extension-podman-quadlet/issues/515.

## Testing

- [x] unit tests has been added

> The full feature can be tested in https://github.com/podman-desktop/extension-podman-quadlet/pull/535