### PR TITLE
fix(provider-service): notify binding

### DIFF
--- a/packages/backend/src/services/provider-service.spec.ts
+++ b/packages/backend/src/services/provider-service.spec.ts
@@ -3,14 +3,19 @@
  */
 import type { provider as Provider, ProviderContainerConnection, Webview } from '@podman-desktop/api';
 
-import { expect, test, vi, beforeEach } from 'vitest';
+import { expect, test, vi, beforeEach, describe } from 'vitest';
 import { ProviderService } from './provider-service';
 
-const providerMock: typeof Provider = {
+const PROVIDER_API_MOCK: typeof Provider = {
   getContainerConnections: vi.fn(),
+  onDidRegisterContainerConnection: vi.fn(),
+  onDidUnregisterContainerConnection: vi.fn(),
+  onDidUpdateContainerConnection: vi.fn(),
 } as unknown as typeof Provider;
 
-const webviewMock: Webview = {} as unknown as Webview;
+const WEBVIEW_MOCK: Webview = {
+  postMessage: vi.fn(),
+} as unknown as Webview;
 
 const WSL_PROVIDER_CONNECTION_MOCK: ProviderContainerConnection = {
   connection: {
@@ -34,17 +39,19 @@ const DOCKER_PROVIDER_CONNECTION_MOCK: ProviderContainerConnection = {
 
 beforeEach(() => {
   vi.resetAllMocks();
+
+  vi.mocked(WEBVIEW_MOCK.postMessage).mockResolvedValue(true);
 });
 
 function getProviderService(): ProviderService {
   return new ProviderService({
-    providers: providerMock,
-    webview: webviewMock,
+    providers: PROVIDER_API_MOCK,
+    webview: WEBVIEW_MOCK,
   });
 }
 
 test('ProviderService#all should use provider api', async () => {
-  vi.mocked(providerMock.getContainerConnections).mockReturnValue([WSL_PROVIDER_CONNECTION_MOCK]);
+  vi.mocked(PROVIDER_API_MOCK.getContainerConnections).mockReturnValue([WSL_PROVIDER_CONNECTION_MOCK]);
 
   const providers = getProviderService();
   const connections = providers.all();
@@ -58,7 +65,7 @@ test('ProviderService#all should use provider api', async () => {
 });
 
 test('ProviderService#all should exclude docker connection', async () => {
-  vi.mocked(providerMock.getContainerConnections).mockReturnValue([
+  vi.mocked(PROVIDER_API_MOCK.getContainerConnections).mockReturnValue([
     WSL_PROVIDER_CONNECTION_MOCK,
     DOCKER_PROVIDER_CONNECTION_MOCK,
   ]);
@@ -71,5 +78,43 @@ test('ProviderService#all should exclude docker connection', async () => {
     providerId: 'podman',
     status: 'started',
     vmType: 'WSL',
+  });
+});
+
+describe('init', () => {
+  beforeEach(() => {
+    vi.mocked(PROVIDER_API_MOCK.getContainerConnections).mockReturnValue([]);
+  });
+
+  test('should register container connections listener', async () => {
+    const providers = getProviderService();
+    await providers.init();
+
+    // listen to new container connection
+    expect(PROVIDER_API_MOCK.onDidRegisterContainerConnection).toHaveBeenCalledOnce();
+    expect(PROVIDER_API_MOCK.onDidRegisterContainerConnection).toHaveBeenCalledWith(expect.any(Function));
+
+    // listen to remove of container connection
+    expect(PROVIDER_API_MOCK.onDidUnregisterContainerConnection).toHaveBeenCalledOnce();
+    expect(PROVIDER_API_MOCK.onDidUnregisterContainerConnection).toHaveBeenCalledWith(expect.any(Function));
+
+    // listen to update of container connection
+    expect(PROVIDER_API_MOCK.onDidUpdateContainerConnection).toHaveBeenCalledOnce();
+    expect(PROVIDER_API_MOCK.onDidUpdateContainerConnection).toHaveBeenCalledWith(expect.any(Function));
+  });
+
+  test('container connection update should notify for events', async () => {
+    const listener = vi.fn();
+
+    const providers = getProviderService();
+    await providers.init();
+
+    // register a listener to the ProviderService
+    providers.event(listener);
+
+    const registerListener = vi.mocked(PROVIDER_API_MOCK.onDidRegisterContainerConnection).mock.calls[0][0];
+    registerListener(WSL_PROVIDER_CONNECTION_MOCK);
+
+    expect(listener).toHaveBeenCalledOnce();
   });
 });

--- a/packages/backend/src/services/provider-service.ts
+++ b/packages/backend/src/services/provider-service.ts
@@ -65,10 +65,10 @@ export class ProviderService
 
   async init(): Promise<void> {
     // register
-    this.#disposables.push(this.dependencies.providers.onDidRegisterContainerConnection(this.notify));
+    this.#disposables.push(this.dependencies.providers.onDidRegisterContainerConnection(this.notify.bind(this)));
     // unregister
-    this.#disposables.push(this.dependencies.providers.onDidUnregisterContainerConnection(this.notify));
-    // update provider (start / stop )
-    this.#disposables.push(this.dependencies.providers.onDidUpdateContainerConnection(this.notify));
+    this.#disposables.push(this.dependencies.providers.onDidUnregisterContainerConnection(this.notify.bind(this)));
+    // update container connection (start / stop )
+    this.#disposables.push(this.dependencies.providers.onDidUpdateContainerConnection(this.notify.bind(this)));
   }
 }


### PR DESCRIPTION
## Description

Fixes an annoying problem happening when a provider connection is getting updated (started / stopped from the resource page) and since the notify function was passed without being binded, was missing the `this` argument.

This lead to an error inside the `Publisher` class `error cannot read `_event` on undefined`.