### PR TITLE
feat(podlet-js): adding telemetry events

### DIFF
--- a/packages/backend/src/services/main-service.ts
+++ b/packages/backend/src/services/main-service.ts
@@ -174,6 +174,7 @@ export class MainService implements Disposable, AsyncInit {
     const podletJS = new PodletJsService({
       containers: containers,
       images: images,
+      telemetry: this.#telemetry,
     });
 
     /**

--- a/packages/backend/src/utils/telemetry-events.ts
+++ b/packages/backend/src/utils/telemetry-events.ts
@@ -10,8 +10,6 @@ export enum TelemetryEvents {
   SYSTEMD_START = 'systemd-start',
   SYSTEMD_STOP = 'systemd-stop',
   // podlet
-  PODLET_INSTALL = 'podlet-install',
   PODLET_GENERATE = 'podlet-generate',
   PODLET_COMPOSE = 'podlet-compose',
-  PODLET_VERSION = 'podlet-version',
 }


### PR DESCRIPTION
## Description

Following https://github.com/podman-desktop/extension-podman-quadlet/issues/298 the telemetry events related to Podlet has been removed, those included 
- PODLET_INSTALL
- PODLET_VERSION
- PODLET_GENERATE
- PODLET_COMPOSE

The two first should be removed, but the two last should be re-implemented.

## Related issues

Fixes https://github.com/podman-desktop/extension-podman-quadlet/issues/508
Required for https://github.com/podman-desktop/extension-podman-quadlet/issues/578

## Testing

- [x] unit tests has been added
