### PR TITLE
fix(Containerfile): hard copy ssh2 package & deps

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -128,7 +128,7 @@ jobs:
       - name: Build Image
         id: build-image
         run: |
-          podman build -t ghcr.io/${{ github.repository_owner }}/pd-extension-quadlet:${{ needs.tag.outputs.extVersion }} .
+          podman build --squash-all -t ghcr.io/${{ github.repository_owner }}/pd-extension-quadlet:${{ needs.tag.outputs.extVersion }} .
           podman push ghcr.io/${{ github.repository_owner }}/pd-extension-quadlet:${{ needs.tag.outputs.extVersion }}
           podman tag ghcr.io/${{ github.repository_owner }}/pd-extension-quadlet:${{ needs.tag.outputs.extVersion }} ghcr.io/${{ github.repository_owner }}/pd-extension-quadlet:latest
           podman push ghcr.io/${{ github.repository_owner }}/pd-extension-quadlet:latest

--- a/Containerfile
+++ b/Containerfile
@@ -17,6 +17,16 @@ COPY --from=builder /app/packages/backend/media/ /extension/media
 COPY --from=builder /app/LICENSE /extension/
 COPY --from=builder /app/packages/backend/icon.png /extension/
 COPY --from=builder /app/README.md /extension/
+# ssh2 package need to be copied
+COPY --from=builder /app/node_modules/ssh2 /extension/dist/node_modules/ssh2
+# ssh2 depends on asn1
+COPY --from=builder /app/node_modules/asn1 /extension/dist/node_modules/asn1
+# asn1 depends on safer-buffer
+COPY --from=builder /app/node_modules/safer-buffer /extension/dist/node_modules/safer-buffer
+# ssh2 depends on bcrypt-pbkdf
+COPY --from=builder /app/node_modules/bcrypt-pbkdf /extension/dist/node_modules/bcrypt-pbkdf
+# bcrypt-pbkdf depends on tweetnacl
+COPY --from=builder /app/node_modules/tweetnacl /extension/dist/node_modules/tweetnacl
 
 LABEL org.opencontainers.image.title="Podman Quadlet Extension" \
         org.opencontainers.image.description="Podman Quadlet Extension" \


### PR DESCRIPTION
## Description

Following investigation in https://github.com/podman-desktop/extension-podman-quadlet/issues/583, I can't find a nice way to use vite to bundle the ssh2 package: manually copying it is the only way I have to make it works...

> :information_source: I know @benoitf you don't like `--squash-all` this is a temporary solution, I want to introduce as minimal change for now :)

