### PR TITLE
feat(podlet-js): support converting compose service with env

### DIFF
--- a/packages/podlet-js/src/compose/models/podman-pod.ts
+++ b/packages/podlet-js/src/compose/models/podman-pod.ts
@@ -21,10 +21,16 @@ export interface PodContainerPort {
   hostPort: number;
 }
 
+export interface PodEnvironment {
+  name: string;
+  value: string;
+}
+
 export interface PodContainer {
   image: string;
   name: string;
   ports?: Array<PodContainerPort>;
+  env?: Array<PodEnvironment>;
 }
 
 export interface PodmanPod {

--- a/packages/podlet-js/src/compose/tests/environments/compose.yaml
+++ b/packages/podlet-js/src/compose/tests/environments/compose.yaml
@@ -1,0 +1,12 @@
+services:
+  redis:
+    image: redislabs/redismod
+    ports:
+      - '6379:6379'
+    environment:
+      - DEBUG=true
+      - FOO=bar
+  nginx:
+    image: nginx:latest
+    environment:
+      USERNAME: foobar

--- a/packages/podlet-js/src/compose/tests/environments/expect.yaml
+++ b/packages/podlet-js/src/compose/tests/environments/expect.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: compose-podified
+spec:
+  containers:
+    - image: redislabs/redismod
+      name: redis
+      ports:
+        - containerPort: 6379
+          hostPort: 6379
+      env:
+        - value: 'true'
+          name: DEBUG
+        - value: bar
+          name: FOO
+    - image: nginx:latest
+      name: nginx
+      env:
+        - value: foobar
+          name: USERNAME


### PR DESCRIPTION
## Description

I have not put much effort into the `Compose => Kube YAML` of the `podlet-js` framework. Let's add some basic feature support.

## Testing

- [x] unit tests has been added

**Manually**

You cannot test it, through the UI it is broken (ref https://github.com/podman-desktop/extension-podman-quadlet/issues/586)