### PR TITLE
fix(podlet-js): compose generate port parsing order

### DIFF
--- a/packages/podlet-js/src/compose/compose.ts
+++ b/packages/podlet-js/src/compose/compose.ts
@@ -57,7 +57,8 @@ export class Compose {
           hostPort: port,
         };
       } else if (typeof port === 'string') {
-        const [containerPort, hostPort] = port.split(':');
+        // Compose spec uses `host:container`
+        const [hostPort, containerPort] = port.split(':');
         return {
           containerPort: Number(containerPort),
           hostPort: Number(hostPort),

--- a/packages/podlet-js/src/compose/tests/nginx/compose.yaml
+++ b/packages/podlet-js/src/compose/tests/nginx/compose.yaml
@@ -1,0 +1,6 @@
+name: nginx-service
+services:
+  nginx:
+    image: docker.io/library/nginx
+    ports:
+      - '8080:80'

--- a/packages/podlet-js/src/compose/tests/nginx/expect.yaml
+++ b/packages/podlet-js/src/compose/tests/nginx/expect.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx-service
+spec:
+  containers:
+    - image: docker.io/library/nginx
+      name: nginx
+      ports:
+        - containerPort: 80
+          hostPort: 8080


### PR DESCRIPTION
## Description

Fixes https://github.com/podman-desktop/extension-podman-quadlet/issues/601

## Testing

- [x] unit test has been added