### PR TITLE
feat(form): validate quadlet filename

### DIFF
--- a/packages/frontend/src/lib/forms/quadlet/QuadletGenerateForm.spec.ts
+++ b/packages/frontend/src/lib/forms/quadlet/QuadletGenerateForm.spec.ts
@@ -160,7 +160,7 @@ describe('validating filename', () => {
   });
 
   test('invalid non-empty filename should display an error', async () => {
-    const input = renderResult.getByRole('textbox', { name: 'Quadlet filename'});
+    const input = renderResult.getByRole('textbox', { name: 'Quadlet filename' });
     expect(input).toBeDefined();
 
     await fireEvent.input(input, { target: { value: 'hello' } });
@@ -172,7 +172,7 @@ describe('validating filename', () => {
   });
 
   test('valid filename should not display an error', async () => {
-    const input = renderResult.getByRole('textbox', { name: 'Quadlet filename'});
+    const input = renderResult.getByRole('textbox', { name: 'Quadlet filename' });
     expect(input).toBeDefined();
 
     await fireEvent.input(input, { target: { value: 'hello' } });

--- a/packages/frontend/src/lib/forms/quadlet/QuadletGenerateForm.spec.ts
+++ b/packages/frontend/src/lib/forms/quadlet/QuadletGenerateForm.spec.ts
@@ -18,7 +18,7 @@
 
 import '@testing-library/jest-dom/vitest';
 
-import { fireEvent, render } from '@testing-library/svelte';
+import { fireEvent, render, type RenderResult } from '@testing-library/svelte';
 import { expect, test, describe, vi, beforeEach } from 'vitest';
 import QuadletGenerateForm from '/@/lib/forms/quadlet/QuadletGenerateForm.svelte';
 import * as connectionStore from '/@store/connections';
@@ -26,6 +26,7 @@ import { readable } from 'svelte/store';
 import type { ProviderContainerConnectionDetailedInfo } from '/@shared/src/models/provider-container-connection-detailed-info';
 import { containerAPI, podletAPI } from '/@/api/client';
 import { QuadletType } from '/@shared/src/utils/quadlet-type';
+import type { Component, ComponentProps } from 'svelte';
 
 // mock clients
 vi.mock('/@/api/client', () => ({
@@ -115,6 +116,78 @@ describe('Step options', () => {
         resourceId: 'dummy-resource-id',
         type: QuadletType.CONTAINER,
       });
+    });
+  });
+});
+
+describe('validating filename', () => {
+  let renderResult: RenderResult<Component<ComponentProps<typeof QuadletGenerateForm>>>;
+
+  /**
+   * Go directly to step 2
+   */
+  beforeEach(async () => {
+    renderResult = render(QuadletGenerateForm, {
+      providerId: WSL_PROVIDER_DETAILED_INFO.providerId,
+      connection: WSL_PROVIDER_DETAILED_INFO.name,
+      resourceId: 'dummy-resource-id',
+      loading: false,
+      close: vi.fn(),
+    });
+
+    const generate: HTMLButtonElement = await vi.waitFor(() => {
+      const element = renderResult.getByRole('button', { name: 'Generate' });
+      expect(element).toBeInstanceOf(HTMLButtonElement);
+      expect(element).toBeEnabled();
+      return element as HTMLButtonElement;
+    });
+
+    await fireEvent.click(generate);
+
+    const loadIntoMachine: HTMLButtonElement = await vi.waitFor(() => {
+      const element = renderResult.getByRole('button', { name: 'Load into machine' });
+      expect(element).toBeInstanceOf(HTMLButtonElement);
+      return element as HTMLButtonElement;
+    });
+
+    expect(loadIntoMachine).toBeDefined();
+  });
+
+  test('expect button to be disabled by default', async () => {
+    const loadIntoMachine = renderResult.getByRole('button', { name: 'Load into machine' });
+
+    expect(loadIntoMachine).toBeDisabled();
+  });
+
+  test('invalid non-empty filename should display an error', async () => {
+    const input = renderResult.getByRole('textbox', { name: 'Quadlet filename'});
+    expect(input).toBeDefined();
+
+    await fireEvent.input(input, { target: { value: 'hello' } });
+
+    await vi.waitFor(() => {
+      const alert = renderResult.getByRole('alert');
+      expect(alert).toHaveTextContent('Quadlet filename should be <name>.container');
+    });
+  });
+
+  test('valid filename should not display an error', async () => {
+    const input = renderResult.getByRole('textbox', { name: 'Quadlet filename'});
+    expect(input).toBeDefined();
+
+    await fireEvent.input(input, { target: { value: 'hello' } });
+
+    // ensure it exists
+    await vi.waitFor(() => {
+      const alert = renderResult.queryByRole('alert');
+      expect(alert).toBeDefined();
+    });
+
+    // fill the input with a valid value (it replace any existing)
+    await fireEvent.input(input, { target: { value: 'hello.container' } });
+    await vi.waitFor(() => {
+      const alert = renderResult.queryByRole('alert');
+      expect(alert).toBeNull();
     });
   });
 });

--- a/packages/frontend/src/lib/forms/quadlet/QuadletGenerateForm.svelte
+++ b/packages/frontend/src/lib/forms/quadlet/QuadletGenerateForm.svelte
@@ -76,6 +76,12 @@ $effect(() => {
 let quadlet: string | undefined = $state(undefined);
 let quadletFilename: string = $state('');
 let loaded: boolean = $state(false);
+let validFilename: boolean = $derived.by(() => {
+  // split filename by . (E.g. foo.container => ['foo', 'container'])
+  const parts = quadletFilename.split('.');
+  // support multiple part (E.g. foo.bar.container => ['foo', 'bar', 'container']
+  return parts.length >= 2 && parts[0].length > 0 && parts[parts.length - 1] === quadletType.toLowerCase();
+});
 
 let step: string = $derived(loaded ? 'completed' : quadlet !== undefined ? 'edit' : 'options');
 
@@ -225,9 +231,12 @@ function resetGenerate(): void {
       <Input
         class="grow"
         name="quadlet filename"
-        placeholder="Quadlet filename (E.g. nginx.container)"
+        placeholder="Quadlet filename (E.g. foo.{quadletType.toLowerCase()})"
         bind:value={quadletFilename}
         id="quadlet-filename" />
+      {#if quadletFilename.length > 0 && !validFilename}
+        <ErrorMessage error="Quadlet filename should be <name>.{quadletType.toLowerCase()}" />
+      {/if}
 
       <div class="h-[400px] pt-4">
         <QuadletEditor bind:content={quadlet} />
@@ -238,7 +247,7 @@ function resetGenerate(): void {
       <div class="w-full flex flex-row gap-x-2 justify-end pt-4">
         <Button type="secondary" on:click={resetGenerate} title="Previous">Previous</Button>
         <Button
-          disabled={quadletFilename.length === 0 || loading}
+          disabled={quadletFilename.length === 0 || loading || !validFilename}
           inProgress={loading}
           icon={faTruckPickup}
           on:click={saveIntoMachine}


### PR DESCRIPTION
## Description

Prevent users from generating invalid quadlet by providing an invalid name; (E.g. when generating Container quadlet, the filename must be `*.container`).

> We could discuss UX, but I would rather first have this to be merge, as a safeguard, then improve the design later one.

## Screenshots

![image](https://github.com/user-attachments/assets/930c7492-e6a4-49f3-8d73-6aa58fe0ecdb)

https://github.com/user-attachments/assets/c6f4179a-15aa-4e30-8e78-1874715bc7d4

## Related issues

Fixes https://github.com/podman-desktop/extension-podman-quadlet/issues/612

## Testing

- [x] unit tests has been provided

**Manually**

1. checkout PR
2. start Podman Desktop
3. Go to Quadlet webview
4. Go to `Generate Quadlet`
5. Select any Quadlets
6. Try to type something in the input
7. assert only validated value are allowed (Load Into Machine would be disabled)