### PR TITLE
test(frontend): ensuring Stepper component is covered

### DIFF
--- a/packages/frontend/src/lib/stepper/Stepper.spec.ts
+++ b/packages/frontend/src/lib/stepper/Stepper.spec.ts
@@ -1,0 +1,90 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+import { render } from '@testing-library/svelte';
+
+import { expect, test, describe, vi, beforeEach } from 'vitest';
+import Stepper from '/@/lib/stepper/Stepper.svelte';
+import type { Step } from './stepper';
+
+// eslint-disable-next-line sonarjs/slow-regex
+const STEP_LABEL_REGEX = /^Step\s+(.+)$/;
+
+const STEPS_MOCK: Array<Step> = [
+  {
+    label: 'Foo',
+    id: 'foo',
+  },
+  {
+    label: 'Bar',
+    id: 'bar',
+  },
+  {
+    label: 'Hello',
+    id: 'hello',
+  },
+  {
+    label: 'Potatoes',
+    id: 'potatoes',
+  },
+];
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+// not related to stepper, but testing the regex used in tests bellow
+describe('step regex', () => {
+  test.each(['Step oui', 'Step Foo', 'Step Bar', 'Step Foo Bar'])('expect %s to be a valid string', str => {
+    expect(STEP_LABEL_REGEX.test(str)).toBeTruthy();
+  });
+
+  test.each(['oui', 'stepper', 'stepper-potatoes'])('expect %s to be an invalid string', str => {
+    expect(STEP_LABEL_REGEX.test(str)).toBeFalsy();
+  });
+});
+
+test('expect stepper to render every step', async () => {
+  const { queryAllByLabelText } = render(Stepper, {
+    value: STEPS_MOCK[0].id,
+    steps: STEPS_MOCK,
+  });
+
+  const stepper = queryAllByLabelText(STEP_LABEL_REGEX);
+  expect(stepper).toHaveLength(STEPS_MOCK.length);
+});
+
+test('expect stepper to set aria-select to selected step', async () => {
+  const selected = STEPS_MOCK[0];
+
+  const { queryAllByLabelText } = render(Stepper, {
+    value: selected.id,
+    steps: STEPS_MOCK,
+  });
+
+  const stepper = queryAllByLabelText(STEP_LABEL_REGEX);
+  expect(stepper).toHaveLength(STEPS_MOCK.length);
+
+  // check all aria-selected that would be true
+  const elements = stepper.filter(step => step.getAttribute('aria-selected') === 'true');
+  expect(elements).toHaveLength(1);
+
+  // ensure this is the expected label
+  expect(elements[0]).toHaveAttribute('aria-label', `Step ${selected.label}`);
+});

--- a/packages/frontend/src/lib/stepper/Stepper.svelte
+++ b/packages/frontend/src/lib/stepper/Stepper.svelte
@@ -1,8 +1,5 @@
 <script lang="ts">
-interface Step {
-  id: string;
-  label: string;
-}
+import type { Step } from '/@/lib/stepper/stepper';
 
 interface Props {
   value: string;
@@ -15,7 +12,11 @@ let { value, steps }: Props = $props();
 <div aria-label="stepper" class="flex items-center w-full pt-4">
   {#each steps as step, index (step.id)}
     {@const selected = step.id === value}
-    <div class:text-purple-500={selected} class="flex items-center justify-center">
+    <div
+      aria-label="Step {step.label}"
+      aria-selected={selected}
+      class:text-purple-500={selected}
+      class="flex items-center justify-center">
       <span
         class:border-purple-500={selected}
         class="flex items-center justify-center w-5 h-5 me-2 text-xs border rounded-full shrink-0">

--- a/packages/frontend/src/lib/stepper/stepper.ts
+++ b/packages/frontend/src/lib/stepper/stepper.ts
@@ -1,0 +1,22 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+export interface Step {
+  id: string;
+  label: string;
+}


### PR DESCRIPTION
## Description

The `Stepper` component is kinda a progress bar, but with some index and named step.

![image](https://github.com/user-attachments/assets/62c27071-f858-4776-b925-dd192a8b35a7)

## Notes

- Improving accessibility (using `aria-select`)
- Improving labels

## Testing

The Stepper was not covered by any tests, and used in the Quadlet Generate Form, and Compose Generate Form.
