### PR TITLE
fix(ssh): prevent reconnect after disposing

### DIFF
--- a/packages/backend/src/utils/remote/connection-handler.spec.ts
+++ b/packages/backend/src/utils/remote/connection-handler.spec.ts
@@ -71,3 +71,30 @@ test('dispose should abort reconnect', async () => {
     expect(handler.counter).toEqual(0);
   });
 });
+
+test('once disposed expect no reconnect', async () => {
+  const handler = new ConnectionHandlerImpl();
+
+  handler.handleReconnect();
+
+  // advance time
+  await vi.advanceTimersByTimeAsync(50_000);
+
+  await vi.waitFor(() => {
+    expect(handler.counter).toEqual(1);
+  });
+
+  // dispose
+  handler.dispose();
+
+  // advance time
+  handler.handleReconnect();
+
+  // advance time
+  await vi.advanceTimersByTimeAsync(50_000);
+
+  // we should not have any reconnect done
+  await vi.waitFor(() => {
+    expect(handler.counter).toEqual(1);
+  });
+});

--- a/packages/backend/src/utils/remote/connection-handler.spec.ts
+++ b/packages/backend/src/utils/remote/connection-handler.spec.ts
@@ -87,7 +87,7 @@ test('once disposed expect no reconnect', async () => {
   // dispose
   handler.dispose();
 
-  // advance time
+  // try to reconnect
   handler.handleReconnect();
 
   // advance time

--- a/packages/backend/src/utils/remote/connection-handler.ts
+++ b/packages/backend/src/utils/remote/connection-handler.ts
@@ -33,7 +33,7 @@ export abstract class ConnectionHandler implements Disposable {
   abstract connect(): Promise<boolean>;
 
   protected handleReconnect(): void {
-    if(this.#disposed) return;
+    if (this.#disposed) return;
     // need to reconnect if no timeout is set for now
     if (!this.#reconnectTimeout) {
       this.#reconnectTimeout = setTimeout(() => {

--- a/packages/backend/src/utils/remote/connection-handler.ts
+++ b/packages/backend/src/utils/remote/connection-handler.ts
@@ -19,6 +19,7 @@ import type { Disposable } from '@podman-desktop/api';
 
 export abstract class ConnectionHandler implements Disposable {
   #reconnectTimeout: NodeJS.Timeout | undefined;
+  #disposed: boolean = false;
 
   dispose(): void {
     // abort any reconnect tentative
@@ -26,11 +27,13 @@ export abstract class ConnectionHandler implements Disposable {
       clearTimeout(this.#reconnectTimeout);
       this.#reconnectTimeout = undefined;
     }
+    this.#disposed = true;
   }
 
   abstract connect(): Promise<boolean>;
 
   protected handleReconnect(): void {
+    if(this.#disposed) return;
     // need to reconnect if no timeout is set for now
     if (!this.#reconnectTimeout) {
       this.#reconnectTimeout = setTimeout(() => {


### PR DESCRIPTION
## Description

Once disposed, we should **not** call the `connect()` method again.

## Related issue
 
Fixes https://github.com/podman-desktop/extension-podman-quadlet/issues/645

## Testing

- [x] unit test has been provided