### PR TITLE
feat: display kube path in details

### DIFF
--- a/packages/backend/src/apis/quadlet-api-impl.spec.ts
+++ b/packages/backend/src/apis/quadlet-api-impl.spec.ts
@@ -95,12 +95,16 @@ function getQuadletApiImpl(): QuadletApiImpl {
 }
 
 test('QuadletApiImpl#getKubeYAML should propagate result from QuadletService#getKubeYAML', async () => {
-  vi.mocked(QUADLET_SERVICE.getKubeYAML).mockResolvedValue('dummy-yaml-content');
+  vi.mocked(QUADLET_SERVICE.getKubeYAML).mockResolvedValue({
+    content: 'dummy-yaml-content',
+    path: 'hello-world',
+  });
 
   const api = getQuadletApiImpl();
 
-  const result = await api.getKubeYAML(WSL_PROVIDER_IDENTIFIER, 'dummy-quadlet-id');
-  expect(result).toStrictEqual('dummy-yaml-content');
+  const { content, path } = await api.getKubeYAML(WSL_PROVIDER_IDENTIFIER, 'dummy-quadlet-id');
+  expect(content).toStrictEqual('dummy-yaml-content');
+  expect(path).toStrictEqual('hello-world');
   expect(PROVIDER_SERVICE.getProviderContainerConnection).toHaveBeenCalledWith(WSL_PROVIDER_IDENTIFIER);
 });
 

--- a/packages/backend/src/apis/quadlet-api-impl.ts
+++ b/packages/backend/src/apis/quadlet-api-impl.ts
@@ -153,7 +153,13 @@ export class QuadletApiImpl extends QuadletApi {
     });
   }
 
-  override async getKubeYAML(connection: ProviderContainerConnectionIdentifierInfo, id: string): Promise<string> {
+  override async getKubeYAML(
+    connection: ProviderContainerConnectionIdentifierInfo,
+    id: string,
+  ): Promise<{
+    content: string;
+    path: string;
+  }> {
     const providerConnection = this.dependencies.providers.getProviderContainerConnection(connection);
 
     return await this.dependencies.quadlet.getKubeYAML({

--- a/packages/backend/src/services/quadlet-service.ts
+++ b/packages/backend/src/services/quadlet-service.ts
@@ -440,7 +440,10 @@ export class QuadletService extends QuadletHelper implements Disposable, AsyncIn
     }));
   }
 
-  async getKubeYAML(options: { id: string; provider: ProviderContainerConnection }): Promise<string> {
+  async getKubeYAML(options: { id: string; provider: ProviderContainerConnection }): Promise<{
+    content: string;
+    path: string;
+  }> {
     const quadlet = this.findQuadlet({
       provider: options.provider,
       id: options.id,
@@ -474,7 +477,11 @@ export class QuadletService extends QuadletHelper implements Disposable, AsyncIn
     try {
       // Get the worker
       const worker: PodmanWorker = await this.podman.getWorker(options.provider);
-      return await worker.read(target);
+      const content = await worker.read(target);
+      return {
+        content: content,
+        path: target,
+      };
     } catch (err: unknown) {
       console.error(`Something went wrong with readTextFile on ${target}`, err);
       // check err is an RunError

--- a/packages/frontend/src/lib/monaco-editor/KubeYamlEditor.spec.ts
+++ b/packages/frontend/src/lib/monaco-editor/KubeYamlEditor.spec.ts
@@ -36,9 +36,12 @@ vi.mock('/@/api/client', () => ({
   },
 }));
 
-const MOCK_YAML = `
+const MOCK_YAML: { content: string; path: string } = {
+  content: `
 foo=bar
-`;
+`,
+  path: '/foo/bar',
+};
 
 beforeEach(() => {
   vi.resetAllMocks();
@@ -73,6 +76,17 @@ test('ensure reload button is visible', async () => {
   await vi.waitFor(() => {
     expect(reloadBtn).toBeEnabled();
   });
+});
+
+test('ensure kube path is visible', async () => {
+  const { getByLabelText } = render(KubeYamlEditor, {
+    quadlet: KUBE_QUADLET,
+    loading: false,
+  });
+
+  const kubeSpan = getByLabelText('kube path');
+  expect(kubeSpan).toBeInTheDocument();
+  expect(kubeSpan).toHaveTextContent(KUBE_QUADLET.path);
 });
 
 test('ensure reload button is disabled when loading true', async () => {
@@ -115,7 +129,7 @@ test('expect result from quadletAPI#getKubeYAML to be displayed in monaco editor
     expect(MonacoEditor).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
-        content: MOCK_YAML,
+        content: MOCK_YAML.content,
       }),
     );
   });

--- a/packages/frontend/src/lib/monaco-editor/KubeYamlEditor.svelte
+++ b/packages/frontend/src/lib/monaco-editor/KubeYamlEditor.svelte
@@ -6,6 +6,7 @@ import type { QuadletInfo } from '/@shared/src/models/quadlet-info';
 import type { QuadletType } from '/@shared/src/utils/quadlet-type';
 import { ErrorMessage, Button } from '@podman-desktop/ui-svelte';
 import { faRotateRight } from '@fortawesome/free-solid-svg-icons/faRotateRight';
+import EditorOverlay from '/@/lib/forms/EditorOverlay.svelte';
 
 interface Props {
   quadlet: QuadletInfo & { type: QuadletType.KUBE };
@@ -14,14 +15,48 @@ interface Props {
 
 let { quadlet, loading = $bindable() }: Props = $props();
 
-let content: string | undefined = $state(undefined);
+let originalContent: string | undefined = $state(undefined);
+let kubeContent: string | undefined = $state(undefined);
 let error: string | undefined = $state(undefined);
+let kubeChanged: boolean = $derived(originalContent !== kubeContent);
+
+let yamlPath: string | undefined = $state(undefined);
 
 async function pull(): Promise<void> {
   loading = true;
   try {
-    content = await quadletAPI.getKubeYAML(quadlet.connection, quadlet.id);
+    const result = await quadletAPI.getKubeYAML(quadlet.connection, quadlet.id);
+    originalContent = result.content;
+    yamlPath = result.path;
+
+    kubeContent = originalContent;
     error = undefined;
+  } catch (err: unknown) {
+    console.error(err);
+    error = `Something went wrong: ${String(err)}`;
+  } finally {
+    loading = false;
+  }
+}
+
+async function saveKube(): Promise<void> {
+  if (!yamlPath || !kubeContent) return;
+
+  loading = true;
+  try {
+    await quadletAPI.writeIntoMachine({
+      connection: quadlet.connection,
+      files: [
+        {
+          content: kubeContent,
+          filename: yamlPath,
+        },
+      ],
+    });
+    // apply to original content
+    originalContent = kubeContent;
+    error = undefined;
+    await pull(); // reload
   } catch (err: unknown) {
     console.error(err);
     error = `Something went wrong: ${String(err)}`;
@@ -35,14 +70,20 @@ onMount(() => {
 });
 </script>
 
-<div class="flex py-2 h-[40px]">
+<div class="flex py-2 h-[40px] gap-x-2">
   <span class="block w-auto text-sm font-medium whitespace-nowrap leading-6 text-[var(--pd-content-text)] pl-2 pr-2">
     <Button icon={faRotateRight} padding="px-2" disabled={loading} title="Reload file" on:click={pull}>Reload</Button>
+  </span>
+  <span
+    aria-label="kube path"
+    class="block w-auto text-sm font-medium whitespace-nowrap leading-6 text-[var(--pd-content-text)] pl-2 pr-2">
+    {quadlet.path}
   </span>
 </div>
 {#if error}
   <ErrorMessage error={error} />
 {/if}
-{#if !loading && content && !error}
-  <MonacoEditor class="h-full" readOnly={true} bind:content={content} language="yaml" />
+{#if !loading && kubeContent && !error}
+  <EditorOverlay save={saveKube} loading={loading} changed={kubeChanged} />
+  <MonacoEditor class="h-full" bind:content={kubeContent} language="yaml" />
 {/if}

--- a/packages/shared/src/apis/quadlet-api.ts
+++ b/packages/shared/src/apis/quadlet-api.ts
@@ -50,7 +50,13 @@ export abstract class QuadletApi {
 
   abstract getSynchronisationInfo(): Promise<SynchronisationInfo[]>;
 
-  abstract getKubeYAML(connection: ProviderContainerConnectionIdentifierInfo, id: string): Promise<string>;
+  abstract getKubeYAML(
+    connection: ProviderContainerConnectionIdentifierInfo,
+    id: string,
+  ): Promise<{
+    content: string;
+    path: string;
+  }>;
 
   /**
    * List Quadlets templates


### PR DESCRIPTION
## Description

Display the absolute path of the kube YAML, this is useful for  https://github.com/podman-desktop/extension-podman-quadlet/issues/651 as of today we only provide the content of the file to the frontend, and we need to know the absolute path to be able to edit it.

## Screenshots

![Screenshot From 2025-06-18 14-42-20](https://github.com/user-attachments/assets/8e879b7b-3e37-4513-bbc9-17713973cbb7)

## Related issues

Required for https://github.com/podman-desktop/extension-podman-quadlet/issues/651.

## Testing

- [x] unit tests have been added