### PR TITLE
feat(kube quadlet): support YAML editing

### DIFF
--- a/packages/backend/src/apis/quadlet-api-impl.ts
+++ b/packages/backend/src/apis/quadlet-api-impl.ts
@@ -144,6 +144,7 @@ export class QuadletApiImpl extends QuadletApi {
   override writeIntoMachine(options: {
     connection: ProviderContainerConnectionIdentifierInfo;
     files: Array<{ filename: string; content: string }>;
+    skipSystemdDaemonReload?: boolean;
   }): Promise<void> {
     const providerConnection = this.dependencies.providers.getProviderContainerConnection(options.connection);
 

--- a/packages/backend/src/services/quadlet-service.ts
+++ b/packages/backend/src/services/quadlet-service.ts
@@ -260,6 +260,11 @@ export class QuadletService extends QuadletHelper implements Disposable, AsyncIn
      */
     admin?: boolean;
     files: Array<{ filename: string; content: string }>;
+    /**
+     * When writing to the machine, by default the code will call systemd daemon-reload
+     * @default false
+     */
+    skipSystemdDaemonReload?: boolean;
   }): Promise<void> {
     const telemetry: Record<string, unknown> = {
       admin: options.admin,
@@ -304,14 +309,16 @@ export class QuadletService extends QuadletHelper implements Disposable, AsyncIn
             }
           }
 
-          // reload
-          await this.dependencies.systemd.daemonReload({
-            admin: options.admin ?? false,
-            provider: options.provider,
-          });
+          if (!options.skipSystemdDaemonReload) {
+            // reload
+            await this.dependencies.systemd.daemonReload({
+              admin: options.admin ?? false,
+              provider: options.provider,
+            });
 
-          // collect quadlets
-          await this.collectPodmanQuadlet();
+            // collect quadlets
+            await this.collectPodmanQuadlet();
+          }
         },
       )
       .catch((err: unknown) => {

--- a/packages/frontend/src/lib/monaco-editor/KubeYamlEditor.svelte
+++ b/packages/frontend/src/lib/monaco-editor/KubeYamlEditor.svelte
@@ -52,6 +52,8 @@ async function saveKube(): Promise<void> {
           filename: yamlPath,
         },
       ],
+      // prevent reloading systemd
+      skipSystemdDaemonReload: true,
     });
     // apply to original content
     originalContent = kubeContent;
@@ -68,6 +70,10 @@ async function saveKube(): Promise<void> {
 onMount(() => {
   pull().catch(console.error);
 });
+
+function onchange(content: string): void {
+  kubeContent = content;
+}
 </script>
 
 <div class="flex py-2 h-[40px] gap-x-2">
@@ -85,5 +91,5 @@ onMount(() => {
 {/if}
 {#if !loading && kubeContent && !error}
   <EditorOverlay save={saveKube} loading={loading} changed={kubeChanged} />
-  <MonacoEditor class="h-full" bind:content={kubeContent} language="yaml" />
+  <MonacoEditor class="h-full" content={kubeContent} onChange={onchange} language="yaml" />
 {/if}

--- a/packages/shared/src/apis/quadlet-api.ts
+++ b/packages/shared/src/apis/quadlet-api.ts
@@ -46,6 +46,11 @@ export abstract class QuadletApi {
   abstract writeIntoMachine(options: {
     connection: ProviderContainerConnectionIdentifierInfo;
     files: Array<{ filename: string; content: string }>;
+    /**
+     * When writing to the machine, by default the code will call systemd daemon-reload
+     * @default false
+     */
+    skipSystemdDaemonReload?: boolean;
   }): Promise<void>;
 
   abstract getSynchronisationInfo(): Promise<SynchronisationInfo[]>;


### PR DESCRIPTION
## Description

Following https://github.com/podman-desktop/extension-podman-quadlet/pull/681, adding the final touch for properly editing yaml file for Kube Quadlets.

> When updating the YAML, we should not call `systemctl daemon-reload`, so adding a `skipSystemdDaemonReload` option to the `QuadletAPI.writeIntoMachine` function.

## Screenshots

https://github.com/user-attachments/assets/1bc3f006-0d83-4ebd-b288-dc659da7f1b4

## Related issues

Fixes https://github.com/podman-desktop/extension-podman-quadlet/issues/651

## Testing

-  [x] unit tests cover the new feature

