### PR TITLE
fix(scripts): use proper base directory for svelte-check

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "format:fix": "prettier --write \"packages/**/*.{ts,js,json,svelte}\"",
     "lint:check": "eslint . --cache",
     "lint:fix": "eslint . --cache --fix",
-    "svelte:check": "svelte-check",
+    "svelte:check": "cd packages/frontend && svelte-check",
     "test:podlet-js": "vitest run --project podlet-js",
     "test:backend":   "vitest run --project quadlet",
     "test:frontend":  "vitest run --project frontend",


### PR DESCRIPTION
## Description

The `svelte-check` command was ran from the root directory, using the `tsconfig.ts` from the root, where it should be using the one from `packages/frontend/tsconfig.ts`

## Related issues

Fixes the linter check in https://github.com/podman-desktop/extension-podman-quadlet/pull/717
