### PR TITLE
chore(pnpm): update to 10.12.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
     "lint:fix": "eslint . --cache --fix",
     "svelte:check": "svelte-check",
     "test:podlet-js": "vitest run --project podlet-js",
-    "test:backend": "vitest run --project quadlet",
-    "test:frontend": "vitest run --project frontend",
-    "test:shared": "vitest run --project shared",
+    "test:backend":   "vitest run --project quadlet",
+    "test:frontend":  "vitest run --project frontend",
+    "test:shared":    "vitest run --project shared",
     "test:unit": "vitest run",
     "test:e2e": "cd tests/playwright && npm run test:e2e",
     "test:e2e:smoke": "cd tests/playwright && npm run test:e2e:smoke",
@@ -39,13 +39,13 @@
     "wrap-ansi": "^7.0.0"
   },
   "devDependencies": {
-    "@eslint/compat": "^1.3.1",
     "@typescript-eslint/eslint-plugin": "^8.35.1",
     "@typescript-eslint/parser": "^8.35.1",
     "@vitest/coverage-v8": "^3.0.9",
     "autoprefixer": "^10.4.21",
     "concurrently": "^9.2.0",
     "eslint": "^9.30.1",
+    "@eslint/compat": "^1.3.1",
     "eslint-import-resolver-custom-alias": "^1.3.2",
     "eslint-import-resolver-typescript": "^4.4.4",
     "eslint-plugin-etc": "^2.0.3",
@@ -56,7 +56,6 @@
     "eslint-plugin-sonarjs": "^3.0.4",
     "eslint-plugin-svelte": "^3.10.1",
     "eslint-plugin-unicorn": "^59.0.1",
-    "globals": "^16.3.0",
     "prettier": "^3.6.2",
     "prettier-plugin-svelte": "^3.4.0",
     "svelte": "5.35.2",
@@ -65,7 +64,8 @@
     "typescript": "5.8.3",
     "typescript-eslint": "^8.35.1",
     "vite": "^6.3.5",
-    "vitest": "^3.0.9"
+    "vitest": "^3.0.9",
+    "globals": "^16.3.0"
   },
   "workspaces": {
     "packages": [

--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
     "lint:fix": "eslint . --cache --fix",
     "svelte:check": "svelte-check",
     "test:podlet-js": "vitest run --project podlet-js",
-    "test:backend":   "vitest run --project quadlet",
-    "test:frontend":  "vitest run --project frontend",
-    "test:shared":    "vitest run --project shared",
+    "test:backend": "vitest run --project quadlet",
+    "test:frontend": "vitest run --project frontend",
+    "test:shared": "vitest run --project shared",
     "test:unit": "vitest run",
     "test:e2e": "cd tests/playwright && npm run test:e2e",
     "test:e2e:smoke": "cd tests/playwright && npm run test:e2e:smoke",
@@ -39,13 +39,13 @@
     "wrap-ansi": "^7.0.0"
   },
   "devDependencies": {
+    "@eslint/compat": "^1.3.1",
     "@typescript-eslint/eslint-plugin": "^8.35.1",
     "@typescript-eslint/parser": "^8.35.1",
     "@vitest/coverage-v8": "^3.0.9",
     "autoprefixer": "^10.4.21",
     "concurrently": "^9.2.0",
     "eslint": "^9.30.1",
-    "@eslint/compat": "^1.3.1",
     "eslint-import-resolver-custom-alias": "^1.3.2",
     "eslint-import-resolver-typescript": "^4.4.4",
     "eslint-plugin-etc": "^2.0.3",
@@ -56,6 +56,7 @@
     "eslint-plugin-sonarjs": "^3.0.4",
     "eslint-plugin-svelte": "^3.10.1",
     "eslint-plugin-unicorn": "^59.0.1",
+    "globals": "^16.3.0",
     "prettier": "^3.6.2",
     "prettier-plugin-svelte": "^3.4.0",
     "svelte": "5.35.2",
@@ -64,8 +65,7 @@
     "typescript": "5.8.3",
     "typescript-eslint": "^8.35.1",
     "vite": "^6.3.5",
-    "vitest": "^3.0.9",
-    "globals": "^16.3.0"
+    "vitest": "^3.0.9"
   },
   "workspaces": {
     "packages": [
@@ -73,5 +73,5 @@
       "tests/*"
     ]
   },
-  "packageManager": "pnpm@10.6.2+sha512.47870716bea1572b53df34ad8647b42962bc790ce2bf4562ba0f643237d7302a3d6a8ecef9e4bdfc01d23af1969aa90485d4cebb0b9638fa5ef1daef656f6c1b"
+  "packageManager": "pnpm@10.12.4+sha512.5ea8b0deed94ed68691c9bad4c955492705c5eeb8a87ef86bc62c74a26b037b08ff9570f108b2e4dbd1dd1a9186fea925e527f141c648e85af45631074680184"
 }

--- a/package.json
+++ b/package.json
@@ -73,5 +73,5 @@
       "tests/*"
     ]
   },
-  "packageManager": "pnpm@9.15.5+sha256.8472168c3e1fd0bff287e694b053fccbbf20579a3ff9526b6333beab8df65a8d"
+  "packageManager": "pnpm@10.6.2+sha512.47870716bea1572b53df34ad8647b42962bc790ce2bf4562ba0f643237d7302a3d6a8ecef9e4bdfc01d23af1969aa90485d4cebb0b9638fa5ef1daef656f6c1b"
 }


### PR DESCRIPTION
## Description

Feel like the https://github.com/podman-desktop/extension-podman-quadlet/pull/724 is failing with the following error

```
Scope: all 19 workspace projects
 ERR_PNPM_LOCKFILE_CONFIG_MISMATCH  Cannot proceed with the frozen installation. The current "patchedDependencies" configuration doesn't match the value found in the lockfile

Update your lockfile using "pnpm install --no-frozen-lockfile"
```

Is probably link to the pnpm version used