### PR TITLE
fix: search by quadlet name not id

### DIFF
--- a/packages/frontend/src/pages/QuadletsList.svelte
+++ b/packages/frontend/src/pages/QuadletsList.svelte
@@ -76,7 +76,7 @@ let data: (QuadletInfo & { selected?: boolean })[] = $derived(
     }
 
     if (match && searchTerm.length > 0) {
-      match = quadlet.service?.includes(searchTerm) || false;
+      match = quadlet.service?.includes(searchTerm) ?? false;
     }
 
     return match;

--- a/packages/frontend/src/pages/QuadletsList.svelte
+++ b/packages/frontend/src/pages/QuadletsList.svelte
@@ -76,7 +76,7 @@ let data: (QuadletInfo & { selected?: boolean })[] = $derived(
     }
 
     if (match && searchTerm.length > 0) {
-      match = quadlet.id.includes(searchTerm);
+      match = quadlet.service?.includes(searchTerm) || false;
     }
 
     return match;


### PR DESCRIPTION
Fix for #757 - The search term uses the service name not the container ID to match
