### PR TITLE
feat(frontend): filter quadlet based on path

### DIFF
--- a/packages/frontend/src/pages/QuadletsList.spec.ts
+++ b/packages/frontend/src/pages/QuadletsList.spec.ts
@@ -190,3 +190,18 @@ test('removing all quadlets should call quadletAPI#remove for each connection', 
     ...QUADLETS_MOCK.filter(quadlet => quadlet.connection === WSL_PROVIDER_DETAILED_INFO).map(({ id }) => id),
   );
 });
+
+test('search should filter based on path', async () => {
+  const { getByRole, getAllByRole } = render(QuadletsList);
+
+  // get toggle all checkbox
+  const textbox = getByRole('textbox', { name: 'search Podman Quadlets' });
+  expect(textbox).toBeDefined();
+
+  await fireEvent.input(textbox, { target: { value: QUADLETS_MOCK[0].path } });
+
+  await vi.waitFor(() => {
+    const checkboxes = getAllByRole('checkbox');
+    expect(checkboxes).toHaveLength(2); // the toggle all + our quadlet row
+  });
+});

--- a/packages/frontend/src/pages/QuadletsList.spec.ts
+++ b/packages/frontend/src/pages/QuadletsList.spec.ts
@@ -18,7 +18,7 @@
 
 import '@testing-library/jest-dom/vitest';
 
-import { fireEvent, render } from '@testing-library/svelte';
+import { fireEvent, render, within } from '@testing-library/svelte';
 
 import * as connectionStore from '/@store/connections';
 import { assert, beforeEach, expect, test, vi } from 'vitest';
@@ -194,14 +194,14 @@ test('removing all quadlets should call quadletAPI#remove for each connection', 
 test('search should filter based on path', async () => {
   const { getByRole, getAllByRole } = render(QuadletsList);
 
-  // get toggle all checkbox
   const textbox = getByRole('textbox', { name: 'search Podman Quadlets' });
-  expect(textbox).toBeDefined();
-
   await fireEvent.input(textbox, { target: { value: QUADLETS_MOCK[0].path } });
 
-  await vi.waitFor(() => {
-    const checkboxes = getAllByRole('checkbox');
-    expect(checkboxes).toHaveLength(2); // the toggle all + our quadlet row
+  const [, content ] = await vi.waitFor(() => {
+    const rows = getAllByRole('row');
+    expect(rows).toHaveLength(2); // the toggle all + our quadlet row
+    return rows;
   });
+  const div = within(content).getByText(QUADLETS_MOCK[0].path);
+  expect(div).toBeDefined();
 });

--- a/packages/frontend/src/pages/QuadletsList.spec.ts
+++ b/packages/frontend/src/pages/QuadletsList.spec.ts
@@ -197,7 +197,7 @@ test('search should filter based on path', async () => {
   const textbox = getByRole('textbox', { name: 'search Podman Quadlets' });
   await fireEvent.input(textbox, { target: { value: QUADLETS_MOCK[0].path } });
 
-  const [, content ] = await vi.waitFor(() => {
+  const [, content] = await vi.waitFor(() => {
     const rows = getAllByRole('row');
     expect(rows).toHaveLength(2); // the toggle all + our quadlet row
     return rows;

--- a/packages/frontend/src/pages/QuadletsList.svelte
+++ b/packages/frontend/src/pages/QuadletsList.svelte
@@ -76,7 +76,7 @@ let data: (QuadletInfo & { selected?: boolean })[] = $derived(
     }
 
     if (match && searchTerm.length > 0) {
-      match = quadlet.service?.includes(searchTerm) ?? false;
+      match = quadlet.path.includes(searchTerm) ?? false;
     }
 
     return match;

--- a/packages/frontend/src/pages/QuadletsList.svelte
+++ b/packages/frontend/src/pages/QuadletsList.svelte
@@ -76,7 +76,7 @@ let data: (QuadletInfo & { selected?: boolean })[] = $derived(
     }
 
     if (match && searchTerm.length > 0) {
-      match = quadlet.path.includes(searchTerm) ?? false;
+      match = quadlet.path.toLowerCase().includes(searchTerm.toLowerCase()) ?? false;
     }
 
     return match;


### PR DESCRIPTION
## Description

Following https://github.com/podman-desktop/extension-podman-quadlet/pull/758, we search by service name, however in some cases the quadlet may not have corresponding service.

We should instead use the path, which is always defined.