### PR TITLE
chore(frontend): improve RadioButtons style

### DIFF
--- a/packages/frontend/src/lib/buttons/RadioButtons.spec.ts
+++ b/packages/frontend/src/lib/buttons/RadioButtons.spec.ts
@@ -54,3 +54,23 @@ test('click on a radio should call onChange prop', async () => {
 
   expect(onChangeMock).toHaveBeenCalledWith(OPTIONS[5].id);
 });
+
+test('disable radio buttons should have proper styling', async () => {
+  const { getByRole, getAllByRole } = render(RadioButtons, {
+    options: OPTIONS,
+    label: 'Example',
+    value: OPTIONS[0].id,
+    onChange: vi.fn(),
+    disabled: true,
+  });
+
+  const group = getByRole('radiogroup', { name: 'Example' });
+  expect(group).toHaveClass('border-[var(--pd-button-disabled)]');
+
+  const buttons = getAllByRole('radio');
+  expect(buttons).toHaveLength(OPTIONS.length);
+  for (const button of buttons) {
+    expect(button).toHaveClass('bg-[var(--pd-button-disabled)]');
+    expect(button).toHaveClass('text-[var(--pd-button-disabled-text)]');
+  }
+});

--- a/packages/frontend/src/lib/buttons/RadioButtons.svelte
+++ b/packages/frontend/src/lib/buttons/RadioButtons.svelte
@@ -23,7 +23,7 @@ function onclick(id: string): void {
 <ul
   role="radiogroup"
   aria-label={label}
-  class:border-[var(--pd-button-secondary)]={!disabled}
+  class:border-[var(--pd-button-primary-bg)]={!disabled}
   class:border-[var(--pd-button-disabled)]={disabled}
   class="text-sm text-center shadow-sm border-[1px] flex overflow-hidden rounded-[4px] h-[32px]">
   {#each options as option (option.id)}

--- a/packages/frontend/src/lib/buttons/RadioButtons.svelte
+++ b/packages/frontend/src/lib/buttons/RadioButtons.svelte
@@ -23,7 +23,9 @@ function onclick(id: string): void {
 <ul
   role="radiogroup"
   aria-label={label}
-  class="text-sm text-center rounded-lg shadow-sm bg-[var(--pd-action-button-bg)] flex overflow-hidden">
+  class:border-[var(--pd-button-secondary)]={!disabled}
+  class:border-[var(--pd-button-disabled)]={disabled}
+  class="text-sm text-center shadow-sm border-[1px] flex overflow-hidden rounded-[4px] h-[32px]">
   {#each options as option (option.id)}
     {@const selected = value === option.id}
     <li class="w-full">
@@ -33,8 +35,13 @@ function onclick(id: string): void {
         onclick={onclick.bind(undefined, option.id)}
         class:bg-[var(--pd-button-primary-bg)]={selected && !disabled}
         class:bg-[var(--pd-button-disabled)]={disabled}
+        class:text-[var(--pd-button-text)]={selected && !disabled}
+        class:text-[var(--pd-button-disabled-text)]={disabled}
+        class:text-[var(--pd-button-secondary)]={!disabled}
+        class:hover:text-[var(--pd-button-text)]={!disabled}
+        class:hover:bg-[var(--pd-button-secondary-hover)]={!disabled}
         class:cursor-not-allowed={disabled}
-        class="inline-block py-2 w-full bg-gray-100"
+        class="inline-block w-full h-full"
         title={option.label}
         aria-label={option.label}
         aria-current="page">


### PR DESCRIPTION
## Description

The RadioButtons were not nicely displayed in light mode (https://github.com/podman-desktop/extension-podman-quadlet/issues/729).

## Screenshots

| Light | Dark |
| --- | --- |
| <img width="1051" height="327" alt="image" src="https://github.com/user-attachments/assets/2d1feba3-7baf-4d80-b184-6569b05e3f45" /> | <img width="1053" height="323" alt="image" src="https://github.com/user-attachments/assets/7ce562d2-725c-4650-bf15-db4ab0b73e90" /> |
| <img width="1051" height="321" alt="image" src="https://github.com/user-attachments/assets/68675c37-d6f9-4fc9-9f52-fd3d8f43c291" /> | <img width="1045" height="315" alt="image" src="https://github.com/user-attachments/assets/c391d8e2-35c1-4b49-be92-7ef5ec0ca38c" /> |
 

## Related issues

Fixes https://github.com/podman-desktop/extension-podman-quadlet/issues/729