### PR TITLE
feat(frontend): group instance under corresponding template

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -26,7 +26,7 @@
     "@fortawesome/free-brands-svg-icons": "^7.0.0",
     "@fortawesome/free-regular-svg-icons": "^7.0.0",
     "@fortawesome/free-solid-svg-icons": "^7.0.0",
-    "@podman-desktop/ui-svelte": "^1.20.2",
+    "@podman-desktop/ui-svelte": "^1.21.0-202508060751-06c73451b76",
     "@sveltejs/vite-plugin-svelte": "6.1.0",
     "@tailwindcss/typography": "^0.5.16",
     "@tailwindcss/vite": "^4.1.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,8 +186,8 @@ importers:
         specifier: ^7.0.0
         version: 7.0.0
       '@podman-desktop/ui-svelte':
-        specifier: ^1.20.2
-        version: 1.20.2(svelte-fa@4.0.4(svelte@5.37.3))(svelte@5.37.3)
+        specifier: ^1.21.0-202508060751-06c73451b76
+        version: 1.21.0-202508060751-06c73451b76(svelte-fa@4.0.4(svelte@5.37.3))(svelte@5.37.3)
       '@sveltejs/vite-plugin-svelte':
         specifier: 6.1.0
         version: 6.1.0(svelte@5.37.3)(vite@7.0.6(@types/node@22.17.0)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.6.1))
@@ -700,40 +700,20 @@ packages:
   '@floating-ui/utils@0.2.8':
     resolution: {integrity: sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig==}
 
-  '@fortawesome/fontawesome-common-types@6.7.2':
-    resolution: {integrity: sha512-Zs+YeHUC5fkt7Mg1l6XTniei3k4bwG/yo3iFUtZWd/pMx9g3fdvkSK9E0FOC+++phXOka78uJcYb8JaFkW52Xg==}
-    engines: {node: '>=6'}
-
   '@fortawesome/fontawesome-common-types@7.0.0':
     resolution: {integrity: sha512-PGMrIYXLGA5K8RWy8zwBkd4vFi4z7ubxtet6Yn13Plf6krRTwPbdlCwlcfmoX0R7B4Z643QvrtHmdQ5fNtfFCg==}
-    engines: {node: '>=6'}
-
-  '@fortawesome/fontawesome-free@6.7.2':
-    resolution: {integrity: sha512-JUOtgFW6k9u4Y+xeIaEiLr3+cjoUPiAuLXoyKOJSia6Duzb7pq+A76P9ZdPDoAoxHdHzq6gE9/jKBGXlZT8FbA==}
     engines: {node: '>=6'}
 
   '@fortawesome/fontawesome-free@7.0.0':
     resolution: {integrity: sha512-X48nISrSOa89zu2VMljC4XaRf8NmgTwQBVHfS2Nu5G00ZwM31oOVrAtGxZF3b6wDYf9lJsf/Eq4cCSFKIkOWPQ==}
     engines: {node: '>=6'}
 
-  '@fortawesome/free-brands-svg-icons@6.7.2':
-    resolution: {integrity: sha512-zu0evbcRTgjKfrr77/2XX+bU+kuGfjm0LbajJHVIgBWNIDzrhpRxiCPNT8DW5AdmSsq7Mcf9D1bH0aSeSUSM+Q==}
-    engines: {node: '>=6'}
-
   '@fortawesome/free-brands-svg-icons@7.0.0':
     resolution: {integrity: sha512-C8oY28gq/Qx/cHReJa2AunKJUHvUZDVoPlSTHtAvjriaNfi+5nugW4cx7yA/xN3f/nYkElw11gFBoJ2xUDDFgg==}
     engines: {node: '>=6'}
 
-  '@fortawesome/free-regular-svg-icons@6.7.2':
-    resolution: {integrity: sha512-7Z/ur0gvCMW8G93dXIQOkQqHo2M5HLhYrRVC0//fakJXxcF1VmMPsxnG6Ee8qEylA8b8Q3peQXWMNZ62lYF28g==}
-    engines: {node: '>=6'}
-
   '@fortawesome/free-regular-svg-icons@7.0.0':
     resolution: {integrity: sha512-qAh0mTaCY22sQzMK2lKBrtn/aR4keUu5XmtdYR7d702laMe0h+Ab4Kj2pExR9HZkKhjKoq8pbwt8Td+mjW/ipQ==}
-    engines: {node: '>=6'}
-
-  '@fortawesome/free-solid-svg-icons@6.7.2':
-    resolution: {integrity: sha512-GsBrnOzU8uj0LECDfD5zomZJIjrPhIlWU82AHwa2s40FKH+kcxQaBvBo3Z4TxyZHIyX8XTDxsyA33/Vx9eFuQA==}
     engines: {node: '>=6'}
 
   '@fortawesome/free-solid-svg-icons@7.0.0':
@@ -901,8 +881,8 @@ packages:
   '@podman-desktop/tests-playwright@1.20.0-202506112247-eb111f3adfc':
     resolution: {integrity: sha512-NiyTJdL4fC+Zz/4Kv/F9GPQw8hssguQ8+y7/hUe8tpqDJEXIfdWBbyNQyCVAaEDP8R9wGaofAOt7TgyLcIH48w==}
 
-  '@podman-desktop/ui-svelte@1.20.2':
-    resolution: {integrity: sha512-dtJ2DSbTZI0YzhZCxkY4jZzkJpK/H8ujUERaL0hBRAaw0BHOEeJOlb27+dSXRJxgIOt0gSkSsa85NtL+/5/5gQ==}
+  '@podman-desktop/ui-svelte@1.21.0-202508060751-06c73451b76':
+    resolution: {integrity: sha512-kzLHIrYRZcsgazplJ3olm+wfK7pi1yxkTbLb2vDKei29rRt4SFw80M7pUTh7KdIbSmgWseAyiWkSrwgSc7VkgA==}
     peerDependencies:
       svelte: ^4.0.0 || ^5.0.0
       svelte-fa: ^4.0.0
@@ -4284,33 +4264,17 @@ snapshots:
 
   '@floating-ui/utils@0.2.8': {}
 
-  '@fortawesome/fontawesome-common-types@6.7.2': {}
-
   '@fortawesome/fontawesome-common-types@7.0.0': {}
 
-  '@fortawesome/fontawesome-free@6.7.2': {}
-
   '@fortawesome/fontawesome-free@7.0.0': {}
-
-  '@fortawesome/free-brands-svg-icons@6.7.2':
-    dependencies:
-      '@fortawesome/fontawesome-common-types': 6.7.2
 
   '@fortawesome/free-brands-svg-icons@7.0.0':
     dependencies:
       '@fortawesome/fontawesome-common-types': 7.0.0
 
-  '@fortawesome/free-regular-svg-icons@6.7.2':
-    dependencies:
-      '@fortawesome/fontawesome-common-types': 6.7.2
-
   '@fortawesome/free-regular-svg-icons@7.0.0':
     dependencies:
       '@fortawesome/fontawesome-common-types': 7.0.0
-
-  '@fortawesome/free-solid-svg-icons@6.7.2':
-    dependencies:
-      '@fortawesome/fontawesome-common-types': 6.7.2
 
   '@fortawesome/free-solid-svg-icons@7.0.0':
     dependencies:
@@ -4508,12 +4472,12 @@ snapshots:
 
   '@podman-desktop/tests-playwright@1.20.0-202506112247-eb111f3adfc': {}
 
-  '@podman-desktop/ui-svelte@1.20.2(svelte-fa@4.0.4(svelte@5.37.3))(svelte@5.37.3)':
+  '@podman-desktop/ui-svelte@1.21.0-202508060751-06c73451b76(svelte-fa@4.0.4(svelte@5.37.3))(svelte@5.37.3)':
     dependencies:
-      '@fortawesome/fontawesome-free': 6.7.2
-      '@fortawesome/free-brands-svg-icons': 6.7.2
-      '@fortawesome/free-regular-svg-icons': 6.7.2
-      '@fortawesome/free-solid-svg-icons': 6.7.2
+      '@fortawesome/fontawesome-free': 7.0.0
+      '@fortawesome/free-brands-svg-icons': 7.0.0
+      '@fortawesome/free-regular-svg-icons': 7.0.0
+      '@fortawesome/free-solid-svg-icons': 7.0.0
       humanize-duration: 3.33.0
       moment: 2.30.1
       svelte: 5.37.3


### PR DESCRIPTION
## Description

Group template quadlets and their corresponding instances

## Screenshots

<img width="1147" height="697" alt="image" src="https://github.com/user-attachments/assets/e57a1cdc-44b1-4834-bae6-347fa64c3352" />

## Related issues

Fixes https://github.com/podman-desktop/extension-podman-quadlet/issues/795

## Testing

- [x] unit tests have been provided

**Manually**

1. Create `sleep@.container` in your podman machine at `/home/user/.config/containers/systemd/sleep@.container`

```
[Unit]
Description=A templated sleepy container

[Container]
Image=quay.io/fedora/fedora
Exec=sleep %i

[Service]
# Restart service when sleep finishes
Restart=always

[Install]
WantedBy=multi-user.target
DefaultInstance=100
```

2. create a corresponding instance using `ln -s sleep@.container sleep@10.container` (inside `/home/user/.config/containers/systemd/`)
3. Click on `Refresh` (inside the Quadlet extension)
4. assert the `sleep@10` is under the `sleep@100` service.