### PR TITLE
fix(frontend): deletion dialog

### DIFF
--- a/packages/frontend/src/lib/table/QuadletActions.spec.ts
+++ b/packages/frontend/src/lib/table/QuadletActions.spec.ts
@@ -118,7 +118,7 @@ test('expect remove action to use dialogAPI#showWarningMessage', async () => {
   await fireEvent.click(removeBtn);
 
   expect(dialogAPI.showWarningMessage).toHaveBeenCalledWith(
-    'Are you sure you want to delete foo.container?',
+    `Are you sure you want to delete ${QUADLET_MOCK.path}?`,
     'Confirm',
     'Cancel',
   );

--- a/packages/frontend/src/lib/table/QuadletActions.svelte
+++ b/packages/frontend/src/lib/table/QuadletActions.svelte
@@ -37,7 +37,7 @@ async function stop(): Promise<void> {
 
 async function remove(): Promise<void> {
   const result = await dialogAPI.showWarningMessage(
-    `Are you sure you want to delete ${object.id}?`,
+    `Are you sure you want to delete ${object.path}?`,
     'Confirm',
     'Cancel',
   );


### PR DESCRIPTION
## Description

The remove dialog was showing the UUID instead of the service path.

## Screenshot

<img width="543" height="247" alt="image" src="https://github.com/user-attachments/assets/a3f3e46c-2279-448f-94de-ffb34d4c2508" />

## Related issue

Fixes https://github.com/podman-desktop/extension-podman-quadlet/issues/799