### PR TITLE
chore(e2e): set `--no-experimental-strip-types` flag for playwright

### DIFF
--- a/tests/playwright/package.json
+++ b/tests/playwright/package.json
@@ -4,8 +4,7 @@
   "description": "Podman Qualdet extension Playwright E2E tests",
   "scripts": {
     "test:e2e:setup": "xvfb-maybe --auto-servernum --server-args='-screen 0 1280x960x24' --",
-    "test:e2e": "npm run test:e2e:setup playwright test src/",
-    "test:e2e:smoke": "npm run test:e2e:setup playwright test src/ --grep @smoke"
+    "test:e2e:smoke": "npm run test:e2e:setup node --no-experimental-strip-types ../../node_modules/playwright/cli.js test src/ --grep @smoke"
   },
   "publisher": "podman-desktop",
   "license": "Apache-2.0",


### PR DESCRIPTION
Since node 22.18, the Type stripping is enabled by default (ref https://nodejs.org/en/blog/release/v22.18.0#type-stripping-is-enabled-by-default)

Playwright have some issue with it, using solution from https://github.com/microsoft/playwright/issues/34263#issuecomment-3173890500

