### PR TITLE
chore(e2e): set `--no-experimental-strip-types` flag for playwright

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -259,6 +259,8 @@ jobs:
       - name: Run E2E Smoke tests
         shell: bash
         run: pnpm test:e2e:smoke
+        env:
+          NODE_OPTIONS: --no-experimental-strip-types
 
       - uses: actions/upload-artifact@v4
         if: always()


### PR DESCRIPTION
Since node 22.18, the Type stripping is enabled by default (ref https://nodejs.org/en/blog/release/v22.18.0#type-stripping-is-enabled-by-default)

Playwright have some issue with it, using solution from https://github.com/microsoft/playwright/issues/34263#issuecomment-3173890500

