### PR TITLE
fix(journalctl): remove unnecessary DBUS_SESSION_BUS_ADDRESS env

### DIFF
--- a/packages/backend/src/apis/quadlet-api-impl.spec.ts
+++ b/packages/backend/src/apis/quadlet-api-impl.spec.ts
@@ -237,7 +237,9 @@ describe('QuadletApiImpl#createQuadletLogger', () => {
       args: ['--user', '--follow', `--unit=${QUADLET_MOCK.service}`, '--output=cat'],
       logger: LOGGER_MOCK,
       token: expect.anything(),
-      env: expect.anything(),
+      env: {
+        SYSTEMD_COLORS: 'true',
+      },
     });
   });
 });

--- a/packages/backend/src/apis/quadlet-api-impl.ts
+++ b/packages/backend/src/apis/quadlet-api-impl.ts
@@ -150,7 +150,6 @@ export class QuadletApiImpl extends QuadletApi {
         args: ['--user', '--follow', `--unit=${quadlet.service}`, '--output=cat'],
         env: {
           SYSTEMD_COLORS: 'true',
-          DBUS_SESSION_BUS_ADDRESS: 'unix:path=/run/user/1000/bus',
         },
         logger: logger,
         // the logger has an internal cancellation token, let's use it


### PR DESCRIPTION
Fixes https://github.com/podman-desktop/extension-podman-quadlet/issues/448

Image to test ` quay.io/rh-ee-astefani/podman-quadlet-prerelease:1756467344`


---

Need confirmation that journalctl logs are accessible in KDE