### PR TITLE
feat: merge vite config in vitest.config.ts

### DIFF
--- a/packages/backend/vitest.config.ts
+++ b/packages/backend/vitest.config.ts
@@ -16,22 +16,18 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 import { join, resolve } from 'node:path';
-import { defineProject } from 'vitest/config';
+import { mergeConfig } from 'vitest/config';
+import viteConfig from './vite.config';
 
-const PACKAGE_ROOT = __dirname;
-const WORKSPACE_ROOT = join(PACKAGE_ROOT, '..', '..');
+const WORKSPACE_ROOT = join(__dirname, '..', '..');
 
-export default defineProject({
-  root: PACKAGE_ROOT,
+export default mergeConfig(viteConfig, {
   test: {
     globals: true,
     environment: 'node',
     include: ['src/**/*.{test,spec}.?(c|m)[jt]s?(x)', 'vitest.setup.spec.ts'],
     alias: {
-      '@podman-desktop/api': resolve(WORKSPACE_ROOT, '__mocks__/@podman-desktop/api.js'),
-      '/@/': join(PACKAGE_ROOT, 'src') + '/',
-      '/@gen/': join(PACKAGE_ROOT, 'src-generated') + '/',
-      '/@shared/': join(PACKAGE_ROOT, '../shared') + '/',
+      '@podman-desktop/api': resolve(WORKSPACE_ROOT, '__mocks__', '@podman-desktop', 'api.js'),
     },
     setupFiles: ['./vitest.setup.ts'],
   },

--- a/packages/frontend/vitest.config.ts
+++ b/packages/frontend/vitest.config.ts
@@ -15,24 +15,15 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
-import { defineProject } from 'vitest/config';
+import { mergeConfig } from 'vitest/config';
+import viteConfig from './vite.config';
 import { join } from 'node:path';
-import { svelte } from '@sveltejs/vite-plugin-svelte';
 import { svelteTesting } from '@testing-library/svelte/vite';
 
-const PACKAGE_ROOT = __dirname;
-const WORKSPACE_ROOT = join(PACKAGE_ROOT, '..', '..');
+const WORKSPACE_ROOT = join(__dirname, '..', '..');
 
-export default defineProject({
-  root: PACKAGE_ROOT,
-  resolve: {
-    alias: {
-      '/@/': join(PACKAGE_ROOT, 'src') + '/',
-      '/@store/': join(PACKAGE_ROOT, 'src', 'stores') + '/',
-      '/@shared/': join(PACKAGE_ROOT, '../shared') + '/',
-    },
-  },
-  plugins: [svelte({ hot: !process.env.VITEST }), svelteTesting()],
+export default mergeConfig(viteConfig, {
+  plugins: [svelteTesting()],
   test: {
     include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
     globals: true,

--- a/packages/podlet-js/vitest.config.ts
+++ b/packages/podlet-js/vitest.config.ts
@@ -16,18 +16,16 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 import { join, resolve } from 'node:path';
-import { defineProject } from 'vitest/config';
+import { mergeConfig } from 'vitest/config';
+import viteConfig from './vite.config';
 
-const PACKAGE_ROOT = __dirname;
-const WORKSPACE_ROOT = join(PACKAGE_ROOT, '..', '..');
+const WORKSPACE_ROOT = join(__dirname, '..', '..');
 
-export default defineProject({
-  root: PACKAGE_ROOT,
+export default mergeConfig(viteConfig, {
   test: {
     include: ['src/**/*.{test,spec}.?(c|m)[jt]s?(x)'],
     alias: {
-      '@podman-desktop/api': resolve(WORKSPACE_ROOT, '__mocks__/@podman-desktop/api.js'),
-      '/@/': join(PACKAGE_ROOT, 'src') + '/',
+      '@podman-desktop/api': resolve(WORKSPACE_ROOT, '__mocks__', '@podman-desktop', 'api.js'),
     },
   },
 });

--- a/packages/shared/vitest.config.ts
+++ b/packages/shared/vitest.config.ts
@@ -16,18 +16,16 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 import { join, resolve } from 'node:path';
-import { defineProject } from 'vitest/config';
+import { mergeConfig } from 'vitest/config';
+import viteConfig from './vite.config';
 
-const PACKAGE_ROOT = __dirname;
-const WORKSPACE_ROOT = join(PACKAGE_ROOT, '..', '..');
+const WORKSPACE_ROOT = join(__dirname, '..', '..');
 
-export default defineProject({
-  root: PACKAGE_ROOT,
+export default mergeConfig(viteConfig, {
   test: {
     include: ['src/**/*.{test,spec}.?(c|m)[jt]s?(x)'],
     alias: {
-      '@podman-desktop/api': resolve(WORKSPACE_ROOT, '__mocks__/@podman-desktop/api.js'),
-      '/@/': join(PACKAGE_ROOT, 'src') + '/',
+      '@podman-desktop/api': resolve(WORKSPACE_ROOT, '__mocks__', '@podman-desktop', 'api.js'),
     },
   },
 });


### PR DESCRIPTION
## Description

Instead of redefining the vite config in the `vitest.config.ts` let's use the `mergeConfig`. This will avoid some annoying issues while migrating to vitest 4

## Related issues

Part of https://github.com/podman-desktop/extension-podman-quadlet/issues/1072

## Tests

-  CI should be 🟢 

