### PR TITLE
fix(backend): handle absolute path and relative path properly

### DIFF
--- a/packages/backend/src/services/quadlet-service.ts
+++ b/packages/backend/src/services/quadlet-service.ts
@@ -320,19 +320,21 @@ export class QuadletService extends QuadletHelper implements Disposable, AsyncIn
 
           // write all files sequentially - do not try to run them in parallel
           for (const { filename, content } of options.files) {
-            // Only retain the basename (avoid path escape)
-            const base = basename(filename);
+            let destination: string;
+            if (isAbsolute(filename) || filename.startsWith('~/')) {
+              destination = filename;
+            } else {
+              if (options.admin) {
+                destination = joinposix('/etc/containers/systemd', filename);
+              } else {
+                destination = joinposix('~/.config/containers/systemd', filename);
+              }
+            }
 
-            // basic path validation
+            // basic name validation
+            const base = basename(destination);
             if (base.length === 0) throw new Error('invalid filename: empty name not allowed');
             if (!base.includes('.')) throw new Error('invalid filename: file without extension are not allowed');
-
-            let destination: string;
-            if (options.admin) {
-              destination = joinposix('/etc/containers/systemd', base);
-            } else {
-              destination = joinposix('~/.config/containers/systemd', base);
-            }
 
             // write the file
             try {


### PR DESCRIPTION
## Desription

According to Podman documentation 

> For unit files placed in subdirectories within /etc/containers/systemd/user/${UID}/ and the other user unit search paths, Quadlet will recursively search and run the unit files present in these subdirectories.

Currently the code assumed quadlets files could only be placed in the root directory of the search paths, so it used `basename` on every path. This is not a valid behaviour as we need to respect the path provided.

To solve this problem we can check if the path is either absolute or relative, and join to the root if relative without using the `basename` function which would lose logic.

## Screenshots

https://github.com/user-attachments/assets/52de3e00-81ce-45ec-8385-2ea64d6d664d

## Related issues

Fixes https://github.com/podman-desktop/extension-podman-quadlet/issues/1049

## Testing

- [x] unit tests have been added

**Test manually**

:bulb: The steps bellow are the steps done in the screen cast above 

1. Checkout branch
2. In the [podman-desktop](https://github.com/podman-desktop/podman-desktop) root directory execute
```bash
$: pnpm watch --extension-folder <root directory of quadlet checkout>/packages/backend/
```
3. Go to `Quadlets` webview
4. Click on `Generate Quadlet`
5. Select your running engines
6. Select images
7. Select any container image (if none are visible, execute `podman pull hello-world`)
8. When writing the name of the file, add a subfolder (E.g. `foo/hello.image`)
9. Click on generate
10. In the Quadlets list, assert the path contains the subfolder we put above
