### PR TITLE
test(podman-service): use vitest v4 compatible syntax

### DIFF
--- a/packages/backend/src/services/podman-service.spec.ts
+++ b/packages/backend/src/services/podman-service.spec.ts
@@ -26,9 +26,6 @@ vi.mock(import('node:os'));
 // mock podman-workers
 vi.mock(import('../utils/worker/podman-ssh-worker'));
 vi.mock(import('../utils/worker/podman-native-worker'));
-vi.mock(import('@podman-desktop/api'), () => ({
-  CancellationTokenSource: vi.fn(),
-}));
 
 const extensionsMock: typeof extensions = {
   getExtension: vi.fn(),


### PR DESCRIPTION
## Description

Update the `packages/backend/src/services/podman-service.spec.ts` to use a vitest v4 compatible syntax.

Split of https://github.com/podman-desktop/extension-podman-quadlet/pull/1037

## Related issues

Required for 
- https://github.com/podman-desktop/extension-podman-quadlet/issues/1072
- https://github.com/podman-desktop/extension-podman-quadlet/issues/481