### PR TITLE
chore(eslint): configure vitest/consistent-test-it

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -195,7 +195,11 @@ export default [
       // disabled as code in this project is not yet compliant:
       'svelte/valid-compile': 'off',
       'no-undef': 'off',
-      'vitest/prefer-import-in-mock': 'error'
+      'vitest/prefer-import-in-mock': 'error',
+      'vitest/consistent-test-it': ["error", {
+        "fn": "test",
+        "withinDescribe": "test",
+      }]
     },
   },
 


### PR DESCRIPTION
## Description

Enable [vitest/consistent-test-it](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/consistent-test-it.md) (enforce usage of `test`, deny usage if `it`)