### PR TITLE
chore(package.json): update typecheck:frontend run config

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "test:e2e": "cd tests/playwright && npm run test:e2e",
     "test:e2e:smoke": "cd tests/playwright && npm run test:e2e:smoke",
     "typecheck:shared": "tsc --noEmit --project packages/shared",
-    "typecheck:frontend": "tsc --noEmit --project packages/frontend && cd packages/frontend && pnpm check",
+    "typecheck:frontend": "cd packages/frontend && pnpm check",
     "typecheck:backend": "tsc --noEmit --project packages/backend",
     "typecheck:podlet-js": "tsc --noEmit --project packages/podlet-js",
     "typecheck": "npm run typecheck:shared && npm run typecheck:frontend && npm run typecheck:backend && npm run typecheck:podlet-js"


### PR DESCRIPTION
## Description

tsc is not typechecking properly the sveltes files, meaning it incorrectly types the components. `svelte-check` is doing typecheck for **all** files, so doing `tsc + svelte-check` is redundant, we should only be doing `svelte-check`.

## Related issues 

Required for https://github.com/podman-desktop/extension-podman-quadlet/pull/1103