### PR TITLE
chore(frontend): rephrase error message for quadlet name

### DIFF
--- a/packages/frontend/src/lib/forms/quadlet/QuadletGenerateForm.spec.ts
+++ b/packages/frontend/src/lib/forms/quadlet/QuadletGenerateForm.spec.ts
@@ -186,7 +186,7 @@ describe('validating filename', () => {
 
     await vi.waitFor(() => {
       const alert = renderResult.getByRole('alert');
-      expect(alert).toHaveTextContent('Quadlet filename should be <name>.container');
+      expect(alert).toHaveTextContent('Quadlet filename must be <name>.container');
     });
   });
 

--- a/packages/frontend/src/lib/forms/quadlet/QuadletGenerateForm.svelte
+++ b/packages/frontend/src/lib/forms/quadlet/QuadletGenerateForm.svelte
@@ -242,7 +242,7 @@ function resetGenerate(): void {
         bind:value={quadletFilename}
         id="quadlet-filename" />
       {#if quadletFilename.length > 0 && !validFilename}
-        <ErrorMessage error="Quadlet filename should be <name>.{quadletType.toLowerCase()}" />
+        <ErrorMessage error="Quadlet filename must be <name>.{quadletType.toLowerCase()}" />
       {/if}
 
       <div class="h-[400px] pt-4">


### PR DESCRIPTION
## Description

Raised by @cdrage, the wording was incorrect, using `should` when it was mandatory (We must use `must`)

## Screenshots

<img width="392" height="114" alt="image" src="https://github.com/user-attachments/assets/185d8e0f-feb5-4555-8344-f23da853f5a9" />

## Related issues

Fixes https://github.com/podman-desktop/extension-podman-quadlet/issues/1112

## Testing

- [x] Unit test have been updated