### PR TITLE
fix(ipc): prevent QuadletApi#refresh timeout

### DIFF
--- a/packages/shared/src/messages/constants.ts
+++ b/packages/shared/src/messages/constants.ts
@@ -6,4 +6,5 @@ export const noTimeoutChannels: string[] = [
   getChannel(DialogApi, 'showWarningMessage'),
   getChannel(QuadletApi, 'start'),
   getChannel(QuadletApi, 'writeIntoMachine'),
+  getChannel(QuadletApi, 'refresh'),
 ];


### PR DESCRIPTION
## Description

When dealing with multiple connections, the timeout is reached easily on refresh, let's add it to the list of no timeout IPC

## Related issues

Fixes https://github.com/podman-desktop/extension-podman-quadlet/issues/1116