### PR TITLE
chore(QuadletGenerateForm): capitalize quadlet types

### DIFF
--- a/packages/frontend/src/lib/forms/quadlet/QuadletGenerateForm.svelte
+++ b/packages/frontend/src/lib/forms/quadlet/QuadletGenerateForm.svelte
@@ -198,11 +198,11 @@ function resetGenerate(): void {
         value={quadletType}
         options={[
           {
-            label: 'container',
+            label: 'Container',
             id: QuadletType.CONTAINER,
           },
           {
-            label: 'image',
+            label: 'Image',
             id: QuadletType.IMAGE,
           },
         ]} />

--- a/tests/playwright/src/quadlet-extension.spec.ts
+++ b/tests/playwright/src/quadlet-extension.spec.ts
@@ -146,8 +146,8 @@ test.describe.serial(`Podman Quadlet extension installation and verification`, {
 
       // select the image
       const options = await generateForm.quadletType.getOptions();
-      playExpect(options).toContain('image');
-      await generateForm.quadletType.select('image');
+      playExpect(options).toContain('Image');
+      await generateForm.quadletType.select('Image');
 
       // wait for loading to be finished
       await playExpect


### PR DESCRIPTION
## Description

Raised by @cdrage , the Quadlet types were in lowercase, let's capitalize them

## Screenshots

<img width="945" height="109" alt="image" src="https://github.com/user-attachments/assets/fd99fc97-1c62-479b-9656-a09ff5248a47" />

## Related issues

Fixes https://github.com/podman-desktop/extension-podman-quadlet/issues/1111