### PR TITLE
feat(BaseQuadlet): adding resources property

### DIFF
--- a/packages/backend/src/apis/quadlet-api-impl.spec.ts
+++ b/packages/backend/src/apis/quadlet-api-impl.spec.ts
@@ -74,6 +74,7 @@ const QUADLET_MOCK: ServiceQuadlet = {
   content: 'dummy-content',
   type: QuadletType.CONTAINER,
   requires: [],
+  resources: [],
 };
 
 const TEMPLATE_QUADLET_MOCK: TemplateQuadlet & ServiceQuadlet = {
@@ -84,6 +85,7 @@ const TEMPLATE_QUADLET_MOCK: TemplateQuadlet & ServiceQuadlet = {
   content: 'dummy-content',
   type: QuadletType.CONTAINER,
   requires: [],
+  resources: [],
   template: 'foo',
   defaultInstance: undefined, // no default instance
 };

--- a/packages/backend/src/services/quadlet-service.spec.ts
+++ b/packages/backend/src/services/quadlet-service.spec.ts
@@ -108,6 +108,7 @@ const QUADLET_MOCK: ServiceQuadlet = {
   content: 'dummy-content',
   type: QuadletType.CONTAINER,
   requires: [],
+  resources: [],
 };
 
 const TEMPLATE_QUADLET_MOCK: TemplateQuadlet & ServiceQuadlet = {
@@ -118,6 +119,7 @@ const TEMPLATE_QUADLET_MOCK: TemplateQuadlet & ServiceQuadlet = {
   content: 'dummy-content',
   type: QuadletType.CONTAINER,
   requires: [],
+  resources: [],
   template: 'foo',
   defaultInstance: undefined,
 };
@@ -130,6 +132,7 @@ const TEMPLATE_INSTANCE_QUADLET_MOCK: TemplateInstanceQuadlet & ServiceQuadlet =
   content: 'dummy-content',
   type: QuadletType.CONTAINER,
   requires: [],
+  resources: [],
   template: 'foo',
   argument: 'bar',
 };
@@ -142,6 +145,7 @@ const KUBE_QUADLET_MOCK: ServiceQuadlet = {
   content: 'dummy-content',
   type: QuadletType.KUBE,
   requires: [],
+  resources: [],
 };
 
 const SERVICE_LESS_QUADLET_MOCK: Quadlet = {
@@ -151,6 +155,7 @@ const SERVICE_LESS_QUADLET_MOCK: Quadlet = {
   service: undefined,
   type: QuadletType.CONTAINER,
   requires: [],
+  resources: [],
 };
 
 const PROGRESS_REPORT: Progress<{ message?: string; increment?: number }> = {
@@ -395,6 +400,7 @@ describe('QuadletService#remove', () => {
     service: undefined,
     type: QuadletType.CONTAINER,
     requires: [],
+    resources: [],
   }));
 
   beforeEach(() => {

--- a/packages/backend/src/utils/parsers/quadlet-dryrun-parser.ts
+++ b/packages/backend/src/utils/parsers/quadlet-dryrun-parser.ts
@@ -77,6 +77,7 @@ export class QuadletDryRunParser extends Parser<RunResult & { exitCode?: number 
         state: 'error',
         type: type,
         requires: [], // cannot detect requires
+        resources: [], // cannot detect resources
       };
 
       const [serviceType, result] = new QuadletServiceTypeParser({

--- a/packages/backend/src/utils/parsers/quadlet-unit-parser.ts
+++ b/packages/backend/src/utils/parsers/quadlet-unit-parser.ts
@@ -73,6 +73,7 @@ export class QuadletUnitParser extends Parser<string, Quadlet> {
       state: 'unknown',
       type: type,
       requires: unit.Requires,
+      resources: [], // TODO
     };
 
     const [serviceType, result] = new QuadletServiceTypeParser({

--- a/packages/frontend/src/lib/monaco-editor/KubeYamlEditor.spec.ts
+++ b/packages/frontend/src/lib/monaco-editor/KubeYamlEditor.spec.ts
@@ -64,6 +64,7 @@ const KUBE_QUADLET: QuadletInfo & { type: QuadletType.KUBE } = {
   state: 'active',
   connection: PODMAN_MACHINE_DEFAULT,
   requires: [],
+  resources: [],
 };
 
 test('ensure reload button is visible', async () => {

--- a/packages/frontend/src/lib/table/QuadletActions.spec.ts
+++ b/packages/frontend/src/lib/table/QuadletActions.spec.ts
@@ -55,6 +55,7 @@ const QUADLET_MOCK: QuadletInfo = {
   connection: PROVIDER_MOCK,
   type: QuadletType.CONTAINER,
   requires: [],
+  resources: [],
 };
 
 const TEMPLATE_QUADLET_MOCK: QuadletInfo & TemplateQuadlet = {
@@ -65,6 +66,7 @@ const TEMPLATE_QUADLET_MOCK: QuadletInfo & TemplateQuadlet = {
   content: 'dummy-content',
   type: QuadletType.CONTAINER,
   requires: [],
+  resources: [],
   template: 'foo',
   defaultInstance: undefined,
   connection: PROVIDER_MOCK,

--- a/packages/frontend/src/lib/table/QuadletName.spec.ts
+++ b/packages/frontend/src/lib/table/QuadletName.spec.ts
@@ -45,6 +45,7 @@ const QUADLET_MOCK: QuadletInfo = {
   connection: PROVIDER_MOCK,
   type: QuadletType.CONTAINER,
   requires: [],
+  resources: [],
   service: undefined,
 };
 

--- a/packages/frontend/src/lib/table/QuadletStatus.spec.ts
+++ b/packages/frontend/src/lib/table/QuadletStatus.spec.ts
@@ -47,6 +47,7 @@ const QUADLET_MOCK: QuadletInfo = {
   connection: PROVIDER_MOCK,
   type: QuadletType.CONTAINER,
   requires: [],
+  resources: [],
 };
 
 const TEMPLATE_QUADLET_MOCK: QuadletInfo & TemplateQuadlet = {
@@ -57,6 +58,7 @@ const TEMPLATE_QUADLET_MOCK: QuadletInfo & TemplateQuadlet = {
   connection: PROVIDER_MOCK,
   type: QuadletType.CONTAINER,
   requires: [],
+  resources: [],
   template: 'foo',
   defaultInstance: undefined,
 };

--- a/packages/frontend/src/pages/QuadletDetails.spec.ts
+++ b/packages/frontend/src/pages/QuadletDetails.spec.ts
@@ -71,6 +71,7 @@ const CONTAINER_QUADLET_MOCK: QuadletInfo = {
   path: `bar/foo.container`,
   type: QuadletType.CONTAINER,
   requires: [],
+  resources: [],
 };
 
 const CONTAINER_TEMPLATE_QUADLET_MOCK: QuadletInfo & ServiceQuadlet & TemplateQuadlet = {
@@ -84,6 +85,7 @@ const CONTAINER_TEMPLATE_QUADLET_MOCK: QuadletInfo & ServiceQuadlet & TemplateQu
   requires: [],
   template: 'foo',
   defaultInstance: undefined,
+  resources: [],
 };
 
 const IMAGE_QUADLET_MOCK: QuadletInfo = {
@@ -96,6 +98,7 @@ const IMAGE_QUADLET_MOCK: QuadletInfo = {
   path: `bar/foo.image`,
   type: QuadletType.IMAGE,
   requires: [],
+  resources: [],
 };
 
 const INVALID_IMAGE_QUADLET_MOCK: QuadletInfo = {
@@ -106,6 +109,7 @@ const INVALID_IMAGE_QUADLET_MOCK: QuadletInfo = {
   path: `bar/foo.image`,
   type: QuadletType.IMAGE,
   requires: [],
+  resources: [],
   service: undefined,
 };
 
@@ -117,6 +121,7 @@ const KUBE_QUADLET_MOCK: QuadletInfo = {
   path: `bar/foo.kube`,
   type: QuadletType.KUBE,
   requires: [],
+  resources: [],
   service: undefined,
 };
 

--- a/packages/frontend/src/pages/QuadletsList.spec.ts
+++ b/packages/frontend/src/pages/QuadletsList.spec.ts
@@ -83,6 +83,7 @@ const QUADLETS_MOCK: Array<QuadletInfo> = Array.from({ length: 10 }, (_, index) 
   path: `bar/foo-${index}.container`,
   type: QuadletType.CONTAINER,
   requires: [],
+  resources: [],
 }));
 
 beforeEach(() => {
@@ -225,6 +226,7 @@ describe('templates', () => {
     requires: [],
     template: 'foo',
     defaultInstance: undefined,
+    resources: [],
   };
 
   const TEMPLATE_INSTANCE_QUADLET: QuadletInfo & TemplateInstanceQuadlet = {
@@ -238,6 +240,7 @@ describe('templates', () => {
     path: `foo@bar.container`,
     type: QuadletType.CONTAINER,
     requires: [],
+    resources: [],
   };
 
   test('template quadlet with same name on different engine should be renderer apart', async () => {

--- a/packages/frontend/src/utils/quadlet.spec.ts
+++ b/packages/frontend/src/utils/quadlet.spec.ts
@@ -38,6 +38,7 @@ test.each(Object.values(QuadletType).filter(type => type !== QuadletType.KUBE))(
         state: 'active',
         connection: PODMAN_MACHINE_DEFAULT,
         requires: [],
+        resources: [],
       }),
     ).toBeFalsy();
   },
@@ -53,6 +54,7 @@ test(`expect ${QuadletType.KUBE} to be recognised`, () => {
       state: 'active',
       connection: PODMAN_MACHINE_DEFAULT,
       requires: [],
+      resources: [],
     }),
   ).toBeTruthy();
 });

--- a/packages/shared/src/models/base-quadlet.ts
+++ b/packages/shared/src/models/base-quadlet.ts
@@ -20,6 +20,11 @@ import type { QuadletType } from '../utils/quadlet-type';
 
 export type QuadletState = 'active' | 'inactive' | 'deleting' | 'unknown' | 'error';
 
+export interface FileReference {
+  name: string;
+  path: string;
+}
+
 export interface BaseQuadlet {
   /**
    * UUID to internally identify the quadlet
@@ -44,4 +49,8 @@ export interface BaseQuadlet {
    * @remarks the string are the service name, not the quadlet ids.
    */
   requires: Array<string>;
+  /**
+   * A Quadlet can have resources (files) associated with them
+   */
+  resources: Array<FileReference>;
 }


### PR DESCRIPTION
## Description

A Quadlet may have associated _resources_, for example yaml file(s) for a Kube Quadlet, or some env files for Container Quadlets, currently we expose a `QuadletAPI#getKubeYaml` but as mentioned in https://github.com/podman-desktop/extension-podman-quadlet/issues/1054 this is not scalable nor generic enough.

To be more generic, let's introduce a new `resources` field on the `BaseQuadlet` interface. In the next PR we will populate this field.

Split of https://github.com/podman-desktop/extension-podman-quadlet/pull/1107 (Full feature can be tested here)

