### PR TITLE
fix: update monaco editor imports

### DIFF
--- a/packages/frontend/src/lib/monaco-editor/MonacoEditor.spec.ts
+++ b/packages/frontend/src/lib/monaco-editor/MonacoEditor.spec.ts
@@ -21,7 +21,7 @@ import '@testing-library/jest-dom/vitest';
 import { render } from '@testing-library/svelte';
 import { beforeEach, test, vi, expect, describe } from 'vitest';
 import MonacoEditor from '/@/lib/monaco-editor/MonacoEditor.svelte';
-import { editor } from 'monaco-editor/esm/vs/editor/editor.api';
+import { editor } from 'monaco-editor/esm/vs/editor/editor.api.js';
 
 /**
  * mock all monaco core component
@@ -29,14 +29,14 @@ import { editor } from 'monaco-editor/esm/vs/editor/editor.api';
  * /!\ If your code is importing a mocked module, without any associated __mocks__ file or factory for this module,
  * Vitest will mock the module itself by invoking it and mocking every export.
  */
-vi.mock(import('monaco-editor/esm/vs/editor/editor.api'), () => ({
+vi.mock(import('monaco-editor/esm/vs/editor/editor.api.js'), () => ({
   editor: {
     defineTheme: vi.fn(),
     create: vi.fn(),
   } as unknown as typeof editor,
 }));
-vi.mock(import('monaco-editor/esm/vs/basic-languages/ini/ini.contribution'), () => ({}));
-vi.mock(import('monaco-editor/esm/vs/basic-languages/yaml/yaml.contribution'), () => ({}));
+vi.mock(import('monaco-editor/esm/vs/basic-languages/ini/ini.contribution.js'), () => ({}));
+vi.mock(import('monaco-editor/esm/vs/basic-languages/yaml/yaml.contribution.js'), () => ({}));
 
 const EDITOR_MOCK: editor.IStandaloneCodeEditor = {
   dispose: vi.fn(),

--- a/packages/frontend/src/lib/monaco-editor/MonacoEditor.svelte
+++ b/packages/frontend/src/lib/monaco-editor/MonacoEditor.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { onDestroy, onMount } from 'svelte';
-import type * as Monaco from 'monaco-editor/esm/vs/editor/editor.api';
+import type * as Monaco from 'monaco-editor/esm/vs/editor/editor.api.js';
 import type { HTMLAttributes } from 'svelte/elements';
 import { MonacoManager } from '/@/lib/monaco-editor/monaco';
 

--- a/packages/frontend/src/lib/monaco-editor/monaco.spec.ts
+++ b/packages/frontend/src/lib/monaco-editor/monaco.spec.ts
@@ -19,7 +19,7 @@ import '@testing-library/jest-dom/vitest';
 
 import { beforeEach, test, vi, expect } from 'vitest';
 import { MonacoManager } from '/@/lib/monaco-editor/monaco';
-import type { editor } from 'monaco-editor/esm/vs/editor/editor.api';
+import type { editor } from 'monaco-editor/esm/vs/editor/editor.api.js';
 
 const BG_BLACK_COLOR = '#000000';
 
@@ -29,13 +29,13 @@ const BG_BLACK_COLOR = '#000000';
  * /!\ If your code is importing a mocked module, without any associated __mocks__ file or factory for this module,
  * Vitest will mock the module itself by invoking it and mocking every export.
  */
-vi.mock(import('monaco-editor/esm/vs/editor/editor.api'), () => ({
+vi.mock(import('monaco-editor/esm/vs/editor/editor.api.js'), () => ({
   editor: {
     defineTheme: vi.fn(),
   } as unknown as typeof editor,
 }));
-vi.mock(import('monaco-editor/esm/vs/basic-languages/ini/ini.contribution'), () => ({}));
-vi.mock(import('monaco-editor/esm/vs/basic-languages/yaml/yaml.contribution'), () => ({}));
+vi.mock(import('monaco-editor/esm/vs/basic-languages/ini/ini.contribution.js'), () => ({}));
+vi.mock(import('monaco-editor/esm/vs/basic-languages/yaml/yaml.contribution.js'), () => ({}));
 
 beforeEach(() => {
   vi.resetAllMocks();

--- a/packages/frontend/src/lib/monaco-editor/monaco.ts
+++ b/packages/frontend/src/lib/monaco-editor/monaco.ts
@@ -1,12 +1,12 @@
-import type * as Monaco from 'monaco-editor/esm/vs/editor/editor.api';
+import type * as Monaco from 'monaco-editor/esm/vs/editor/editor.api.js';
 
 export class MonacoManager {
   protected static monaco: typeof Monaco | undefined;
 
   protected static async importLanguages(): Promise<Awaited<unknown>[]> {
     return Promise.all([
-      import('monaco-editor/esm/vs/basic-languages/ini/ini.contribution'),
-      import('monaco-editor/esm/vs/basic-languages/yaml/yaml.contribution'),
+      import('monaco-editor/esm/vs/basic-languages/ini/ini.contribution.js'),
+      import('monaco-editor/esm/vs/basic-languages/yaml/yaml.contribution.js'),
     ]);
   }
 
@@ -17,7 +17,7 @@ export class MonacoManager {
     await this.importLanguages();
 
     // import monaco editor dynamically
-    this.monaco = await import('monaco-editor/esm/vs/editor/editor.api');
+    this.monaco = await import('monaco-editor/esm/vs/editor/editor.api.js');
     this.registerTheme();
 
     // return the full monaco


### PR DESCRIPTION
With Monaco 55 they change their typescript config, and now we need to specify the extension when importing content

Required for https://github.com/podman-desktop/extension-podman-quadlet/pull/1015