### PR TITLE
chore(pr-check): limit permissions to read contents

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -23,6 +23,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   lint-format-typecheck:
     name: linter, formatters


### PR DESCRIPTION
## Description

Limit the permissions for the `pr-check` workflows

## Related issues

Part of https://github.com/podman-desktop/extension-podman-quadlet/issues/481

## Testing

- CI should be :green_circle: 