### PR TITLE
chore(pr-check): limit permissions to read contents

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -19,6 +19,9 @@ name: pr-check
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/podman-desktop/extension-podman-quadlet/security/code-scanning/25](https://github.com/podman-desktop/extension-podman-quadlet/security/code-scanning/25) & https://github.com/podman-desktop/extension-podman-quadlet/issues/481

Co-authored with [@github-advanced-security[bot]](https://github.com/podman-desktop/extension-podman-quadlet/commits?author=github-advanced-security%5Bbot%5D)

```yaml
permissions:
  contents: read
```