### PR TITLE
chore(release.yaml): limit permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,6 +17,9 @@
 
 name: release
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:
@@ -35,6 +38,9 @@ jobs:
   tag:
     name: Tagging
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      pull-requests: write
     outputs:
       githubTag: ${{ steps.TAG_UTIL.outputs.githubTag}}
       extVersion: ${{ steps.TAG_UTIL.outputs.extVersion}}
@@ -117,6 +123,9 @@ jobs:
   build:
     needs: [tag]
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v6
         with:
@@ -137,6 +146,8 @@ jobs:
     needs: [tag, build]
     name: Release
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
     steps:
       - name: id
         run: echo the release id is ${{ needs.tag.outputs.releaseId}}


### PR DESCRIPTION
## Description

Limit the permissions for the `release.yml` workflows

## Related issues

Part of https://github.com/podman-desktop/extension-podman-quadlet/issues/481

## Testing

Next release should be not have any permissions issue :p