### PR TITLE
chore(eslint): configure vitest/no-conditional-in-test

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -220,7 +220,8 @@ export default [
       'vitest/hoisted-apis-on-top': ['error'],
       'vitest/prefer-mock-promise-shorthand': ['error'],
       'vitest/prefer-each': ['error'],
-      'vitest/no-alias-methods': ['error']
+      'vitest/no-alias-methods': ['error'],
+      'vitest/no-conditional-in-test': ['error'],
     },
   },
 

--- a/packages/frontend/src/lib/select/Select.spec.ts
+++ b/packages/frontend/src/lib/select/Select.spec.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 
 import '@testing-library/jest-dom/vitest';
-import { beforeEach, vi, test, expect, describe } from 'vitest';
+import { beforeEach, vi, test, expect, assert, describe } from 'vitest';
 import { render, fireEvent, within } from '@testing-library/svelte';
 import Select from '/@/lib/select/Select.svelte';
 
@@ -147,8 +147,7 @@ describe('clear button', () => {
     // get clear HTMLElement
     const clear = container.querySelector('button[class~="clear-select"]');
     // ensure we have two options
-    expect(clear).not.toBeNull();
-    if (!clear) throw new Error('clear is null');
+    assert(clear, 'clear is null');
 
     await fireEvent.click(clear);
 


### PR DESCRIPTION
## Description

Enable [vitest/no-conditional-in-test](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-conditional-in-test.md)

## Related issues

Part of https://github.com/podman-desktop/extension-podman-quadlet/issues/1086

## Testing

- [x] CI should be :green_circle: 



