### PR TITLE
chore(eslint): configure vitest/prefer-called-exactly-once-with

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -225,6 +225,7 @@ export default [
       'vitest/no-identical-title': ['error'],
       'vitest/prefer-equality-matcher': ['error'],
       'vitest/prefer-to-contain': ['error'],
+      'vitest/prefer-called-exactly-once-with': ['error'],
     },
   },
 

--- a/packages/backend/src/apis/quadlet-api-impl.spec.ts
+++ b/packages/backend/src/apis/quadlet-api-impl.spec.ts
@@ -238,8 +238,7 @@ describe('QuadletApiImpl#createQuadletLogger', () => {
       quadletId: QUADLET_MOCK.id,
     });
 
-    expect(PODMAN_SERVICE.getWorker).toHaveBeenCalledOnce();
-    expect(PODMAN_SERVICE.getWorker).toHaveBeenCalledWith(WSL_PROVIDER_CONNECTION_MOCK);
+    expect(PODMAN_SERVICE.getWorker).toHaveBeenCalledExactlyOnceWith(WSL_PROVIDER_CONNECTION_MOCK);
 
     expect(PODMAN_WORKER_MOCK.journalctlExec).toHaveBeenCalledWith({
       args: ['--user', '--follow', `--unit=${QUADLET_MOCK.service}`, '--output=cat'],

--- a/packages/backend/src/services/podlet-js-service.spec.ts
+++ b/packages/backend/src/services/podlet-js-service.spec.ts
@@ -102,20 +102,22 @@ describe('container quadlets', () => {
     });
 
     // Should get the corresponding engine id
-    expect(CONTAINER_SERVICE_MOCK.getEngineId).toHaveBeenCalledOnce();
-    expect(CONTAINER_SERVICE_MOCK.getEngineId).toHaveBeenCalledWith(CONTAINER_CONNECTION_IDENTIFIER);
+    expect(CONTAINER_SERVICE_MOCK.getEngineId).toHaveBeenCalledExactlyOnceWith(CONTAINER_CONNECTION_IDENTIFIER);
 
     // should get the container inspect info
-    expect(CONTAINER_SERVICE_MOCK.inspectContainer).toHaveBeenCalledOnce();
-    expect(CONTAINER_SERVICE_MOCK.inspectContainer).toHaveBeenCalledWith(ENGINE_ID_MOCK, CONTAINER_INSPECT_MOCK.Id);
+    expect(CONTAINER_SERVICE_MOCK.inspectContainer).toHaveBeenCalledExactlyOnceWith(
+      ENGINE_ID_MOCK,
+      CONTAINER_INSPECT_MOCK.Id,
+    );
 
     // should get the image inspect info
-    expect(IMAGE_SERVICE_MOCK.inspectImage).toHaveBeenCalledOnce();
-    expect(IMAGE_SERVICE_MOCK.inspectImage).toHaveBeenCalledWith(ENGINE_ID_MOCK, CONTAINER_INSPECT_MOCK.Image);
+    expect(IMAGE_SERVICE_MOCK.inspectImage).toHaveBeenCalledExactlyOnceWith(
+      ENGINE_ID_MOCK,
+      CONTAINER_INSPECT_MOCK.Image,
+    );
 
     // should properly call the podlet-js container generator
-    expect(ContainerGenerator).toHaveBeenCalledOnce();
-    expect(ContainerGenerator).toHaveBeenCalledWith({
+    expect(ContainerGenerator).toHaveBeenCalledExactlyOnceWith({
       image: IMAGE_INSPECT_MOCK,
       container: CONTAINER_INSPECT_MOCK,
     });
@@ -177,19 +179,16 @@ describe('image quadlets', () => {
     });
 
     // Should get the corresponding engine id
-    expect(CONTAINER_SERVICE_MOCK.getEngineId).toHaveBeenCalledOnce();
-    expect(CONTAINER_SERVICE_MOCK.getEngineId).toHaveBeenCalledWith(CONTAINER_CONNECTION_IDENTIFIER);
+    expect(CONTAINER_SERVICE_MOCK.getEngineId).toHaveBeenCalledExactlyOnceWith(CONTAINER_CONNECTION_IDENTIFIER);
 
     // nothing related to containers
     expect(CONTAINER_SERVICE_MOCK.inspectContainer).not.toHaveBeenCalledOnce();
 
     // should get the image inspect info
-    expect(IMAGE_SERVICE_MOCK.inspectImage).toHaveBeenCalledOnce();
-    expect(IMAGE_SERVICE_MOCK.inspectImage).toHaveBeenCalledWith(ENGINE_ID_MOCK, IMAGE_INSPECT_MOCK.Id);
+    expect(IMAGE_SERVICE_MOCK.inspectImage).toHaveBeenCalledExactlyOnceWith(ENGINE_ID_MOCK, IMAGE_INSPECT_MOCK.Id);
 
     // should properly call the podlet-js image generator
-    expect(ImageGenerator).toHaveBeenCalledOnce();
-    expect(ImageGenerator).toHaveBeenCalledWith({
+    expect(ImageGenerator).toHaveBeenCalledExactlyOnceWith({
       image: IMAGE_INSPECT_MOCK,
     });
 
@@ -222,12 +221,10 @@ describe('compose', () => {
     });
 
     // ensure the right file is read
-    expect(readFile).toHaveBeenCalledOnce();
-    expect(readFile).toHaveBeenCalledWith('dummy-path', { encoding: 'utf8' });
+    expect(readFile).toHaveBeenCalledExactlyOnceWith('dummy-path', { encoding: 'utf8' });
 
     // expect raw content to be used
-    expect(Compose.fromString).toHaveBeenCalledOnce();
-    expect(Compose.fromString).toHaveBeenCalledWith(COMPOSE_RAW_MOCK);
+    expect(Compose.fromString).toHaveBeenCalledExactlyOnceWith(COMPOSE_RAW_MOCK);
 
     // ensure the compose instance is converted to kube play
     expect(COMPOSE_MOCK.toKubePlay).toHaveBeenCalledOnce();

--- a/packages/backend/src/services/provider-service.spec.ts
+++ b/packages/backend/src/services/provider-service.spec.ts
@@ -91,16 +91,13 @@ describe('init', () => {
     await providers.init();
 
     // listen to new container connection
-    expect(PROVIDER_API_MOCK.onDidRegisterContainerConnection).toHaveBeenCalledOnce();
-    expect(PROVIDER_API_MOCK.onDidRegisterContainerConnection).toHaveBeenCalledWith(expect.any(Function));
+    expect(PROVIDER_API_MOCK.onDidRegisterContainerConnection).toHaveBeenCalledExactlyOnceWith(expect.any(Function));
 
     // listen to remove of container connection
-    expect(PROVIDER_API_MOCK.onDidUnregisterContainerConnection).toHaveBeenCalledOnce();
-    expect(PROVIDER_API_MOCK.onDidUnregisterContainerConnection).toHaveBeenCalledWith(expect.any(Function));
+    expect(PROVIDER_API_MOCK.onDidUnregisterContainerConnection).toHaveBeenCalledExactlyOnceWith(expect.any(Function));
 
     // listen to update of container connection
-    expect(PROVIDER_API_MOCK.onDidUpdateContainerConnection).toHaveBeenCalledOnce();
-    expect(PROVIDER_API_MOCK.onDidUpdateContainerConnection).toHaveBeenCalledWith(expect.any(Function));
+    expect(PROVIDER_API_MOCK.onDidUpdateContainerConnection).toHaveBeenCalledExactlyOnceWith(expect.any(Function));
   });
 
   test('container connection update should notify for events', async () => {

--- a/packages/backend/src/services/quadlet-service.spec.ts
+++ b/packages/backend/src/services/quadlet-service.spec.ts
@@ -285,8 +285,7 @@ describe('QuadletService#collectPodmanQuadlet', () => {
     expect(WINDOW_MOCK.withProgress).toHaveBeenCalledOnce();
 
     // ensure telemetry is prooperly logged
-    expect(TELEMETRY_LOGGER_MOCK.logUsage).toHaveBeenCalledOnce();
-    expect(TELEMETRY_LOGGER_MOCK.logUsage).toHaveBeenCalledWith(TelemetryEvents.QUADLET_COLLECT, {
+    expect(TELEMETRY_LOGGER_MOCK.logUsage).toHaveBeenCalledExactlyOnceWith(TelemetryEvents.QUADLET_COLLECT, {
       error: ERROR,
     });
   });
@@ -636,8 +635,7 @@ describe('QuadletService#writeIntoMachine', () => {
       files: [],
     });
 
-    expect(SYSTEMD_SERVICE_MOCK.daemonReload).toHaveBeenCalledOnce();
-    expect(SYSTEMD_SERVICE_MOCK.daemonReload).toHaveBeenCalledWith({
+    expect(SYSTEMD_SERVICE_MOCK.daemonReload).toHaveBeenCalledExactlyOnceWith({
       admin: false,
       provider: WSL_RUNNING_PROVIDER_CONNECTION_MOCK,
     });

--- a/packages/backend/src/utils/publisher.spec.ts
+++ b/packages/backend/src/utils/publisher.spec.ts
@@ -54,8 +54,7 @@ test('publisher should notify all listeners', async () => {
 
   await vi.waitFor(() => {
     listeners.forEach(listener => {
-      expect(listener).toHaveBeenCalledOnce();
-      expect(listener).toHaveBeenCalledWith('dummyValue');
+      expect(listener).toHaveBeenCalledExactlyOnceWith('dummyValue');
     });
   });
 });

--- a/packages/backend/src/utils/remote/podman-sftp.spec.ts
+++ b/packages/backend/src/utils/remote/podman-sftp.spec.ts
@@ -51,8 +51,7 @@ describe('connect', () => {
   test('connection successful', async () => {
     await podmanSFTP.connect();
 
-    expect(SftpClient.prototype.connect).toHaveBeenCalledOnce();
-    expect(SftpClient.prototype.connect).toHaveBeenCalledWith(SSH_CONFIG_MOCK);
+    expect(SftpClient.prototype.connect).toHaveBeenCalledExactlyOnceWith(SSH_CONFIG_MOCK);
 
     expect(podmanSFTP.connected).toBeTruthy();
   });

--- a/packages/backend/src/utils/remote/podman-ssh.spec.ts
+++ b/packages/backend/src/utils/remote/podman-ssh.spec.ts
@@ -233,8 +233,7 @@ describe('exec', () => {
 
     listener(undefined, CLIENT_CHANNEL_MOCK);
 
-    expect(CANCELLATION_TOKEN_MOCK.onCancellationRequested).toHaveBeenCalledOnce();
-    expect(CANCELLATION_TOKEN_MOCK.onCancellationRequested).toHaveBeenCalledWith(expect.any(Function));
+    expect(CANCELLATION_TOKEN_MOCK.onCancellationRequested).toHaveBeenCalledExactlyOnceWith(expect.any(Function));
 
     const exitListener = getExitListener();
     exitListener(0);
@@ -250,8 +249,7 @@ describe('exec', () => {
     listener(undefined, CLIENT_CHANNEL_MOCK);
 
     const cancelListener = await vi.waitFor(() => {
-      expect(CANCELLATION_TOKEN_MOCK.onCancellationRequested).toHaveBeenCalledOnce();
-      expect(CANCELLATION_TOKEN_MOCK.onCancellationRequested).toHaveBeenCalledWith(expect.any(Function));
+      expect(CANCELLATION_TOKEN_MOCK.onCancellationRequested).toHaveBeenCalledExactlyOnceWith(expect.any(Function));
       return vi.mocked(CANCELLATION_TOKEN_MOCK.onCancellationRequested).mock.calls[0][0];
     });
 

--- a/packages/backend/src/utils/worker/podman-ssh-worker.spec.ts
+++ b/packages/backend/src/utils/worker/podman-ssh-worker.spec.ts
@@ -71,8 +71,7 @@ describe('read', () => {
     const result = await worker.read('/foo.txt');
     expect(result).toEqual(DUMMY_CONTENT);
 
-    expect(PodmanSFTP.prototype.read).toHaveBeenCalledOnce();
-    expect(PodmanSFTP.prototype.read).toHaveBeenCalledWith('/foo.txt');
+    expect(PodmanSFTP.prototype.read).toHaveBeenCalledExactlyOnceWith('/foo.txt');
   });
 });
 
@@ -82,8 +81,7 @@ describe('rm', () => {
 
     await worker.rm('/foo.txt');
 
-    expect(PodmanSFTP.prototype.rm).toHaveBeenCalledOnce();
-    expect(PodmanSFTP.prototype.rm).toHaveBeenCalledWith('/foo.txt');
+    expect(PodmanSFTP.prototype.rm).toHaveBeenCalledExactlyOnceWith('/foo.txt');
   });
 });
 
@@ -93,8 +91,7 @@ describe('write', () => {
 
     await worker.write('/foo.txt', 'bar');
 
-    expect(PodmanSFTP.prototype.write).toHaveBeenCalledOnce();
-    expect(PodmanSFTP.prototype.write).toHaveBeenCalledWith('/foo.txt', 'bar');
+    expect(PodmanSFTP.prototype.write).toHaveBeenCalledExactlyOnceWith('/foo.txt', 'bar');
   });
 });
 
@@ -104,8 +101,7 @@ describe('exec', () => {
 
     await worker.exec('echo');
 
-    expect(PodmanSSH.prototype.exec).toHaveBeenCalledOnce();
-    expect(PodmanSSH.prototype.exec).toHaveBeenCalledWith('echo', undefined);
+    expect(PodmanSSH.prototype.exec).toHaveBeenCalledExactlyOnceWith('echo', undefined);
   });
 
   test('exec without option should proxy to PodmanSSH#exec', async () => {
@@ -113,8 +109,7 @@ describe('exec', () => {
 
     await worker.exec('echo', { args: ['hello'] });
 
-    expect(PodmanSSH.prototype.exec).toHaveBeenCalledOnce();
-    expect(PodmanSSH.prototype.exec).toHaveBeenCalledWith('echo', { args: ['hello'] });
+    expect(PodmanSSH.prototype.exec).toHaveBeenCalledExactlyOnceWith('echo', { args: ['hello'] });
   });
 });
 

--- a/packages/backend/vitest.setup.spec.ts
+++ b/packages/backend/vitest.setup.spec.ts
@@ -29,8 +29,7 @@ describe('EventEmitter', () => {
     // emit
     emitter.fire('potatoes');
     // ensure expected behaviour
-    expect(listener).toHaveBeenCalledOnce();
-    expect(listener).toHaveBeenCalledWith('potatoes');
+    expect(listener).toHaveBeenCalledExactlyOnceWith('potatoes');
   });
 
   test('EventEmitter#event should provide a disposable', () => {
@@ -70,8 +69,7 @@ describe('EventEmitter', () => {
     emitter.fire('potatoes');
     // ensure expected behaviour
     listeners.forEach(listener => {
-      expect(listener).toHaveBeenCalledOnce();
-      expect(listener).toHaveBeenCalledWith('potatoes');
+      expect(listener).toHaveBeenCalledExactlyOnceWith('potatoes');
     });
   });
 });

--- a/packages/frontend/src/lib/monaco-editor/FileEditor.spec.ts
+++ b/packages/frontend/src/lib/monaco-editor/FileEditor.spec.ts
@@ -197,8 +197,7 @@ test('expect save button to be enabled when content is updated', async () => {
   saveBtn.click();
 
   await vi.waitFor(() => {
-    expect(quadletAPI.writeIntoMachine).toHaveBeenCalledOnce();
-    expect(quadletAPI.writeIntoMachine).toHaveBeenCalledWith({
+    expect(quadletAPI.writeIntoMachine).toHaveBeenCalledExactlyOnceWith({
       connection: PODMAN_MACHINE_DEFAULT,
       files: [
         {

--- a/packages/frontend/src/lib/select/Select.spec.ts
+++ b/packages/frontend/src/lib/select/Select.spec.ts
@@ -152,8 +152,7 @@ describe('clear button', () => {
     await fireEvent.click(clear);
 
     await vi.waitFor(() => {
-      expect(onChangeMock).toHaveBeenCalledWith(undefined);
-      expect(onChangeMock).toHaveBeenCalledOnce();
+      expect(onChangeMock).toHaveBeenCalledExactlyOnceWith(undefined);
     });
   });
 

--- a/packages/shared/src/messages/message-proxy.spec.ts
+++ b/packages/shared/src/messages/message-proxy.spec.ts
@@ -197,8 +197,7 @@ describe('subscribe', () => {
   test('subscriber should be called on event received', async () => {
     const rpcBrowser = new RpcBrowser(window, api);
 
-    expect(window.addEventListener).toHaveBeenCalledOnce();
-    expect(window.addEventListener).toHaveBeenCalledWith('message', expect.any(Function));
+    expect(window.addEventListener).toHaveBeenCalledExactlyOnceWith('message', expect.any(Function));
     const messageListener = vi.mocked(window.addEventListener).mock.calls[0][1] as (event: MessageEvent) => void;
 
     const listener = vi.fn();
@@ -217,8 +216,7 @@ describe('subscribe', () => {
   test('all subscribers should be called if multiple exists', async () => {
     const rpcBrowser = new RpcBrowser(window, api);
 
-    expect(window.addEventListener).toHaveBeenCalledOnce();
-    expect(window.addEventListener).toHaveBeenCalledWith('message', expect.any(Function));
+    expect(window.addEventListener).toHaveBeenCalledExactlyOnceWith('message', expect.any(Function));
     const messageListener = vi.mocked(window.addEventListener).mock.calls[0][1] as (event: MessageEvent) => void;
 
     const listeners = Array.from({ length: 10 }, _ => vi.fn());
@@ -240,8 +238,7 @@ describe('subscribe', () => {
   test('subscribers which unsubscribe should should be called', async () => {
     const rpcBrowser = new RpcBrowser(window, api);
 
-    expect(window.addEventListener).toHaveBeenCalledOnce();
-    expect(window.addEventListener).toHaveBeenCalledWith('message', expect.any(Function));
+    expect(window.addEventListener).toHaveBeenCalledExactlyOnceWith('message', expect.any(Function));
     const messageListener = vi.mocked(window.addEventListener).mock.calls[0][1] as (event: MessageEvent) => void;
 
     const [listenerA, listenerB] = [vi.fn(), vi.fn()];


### PR DESCRIPTION
## Description

Configure `vitest/prefer-called-exactly-once-with` & run autofix

## Related issues

Part of https://github.com/podman-desktop/extension-podman-quadlet/issues/1086