### PR TITLE
fix(flatpak): realpath systemd-path generators

### DIFF
--- a/packages/backend/src/utils/quadlet-binary-resolver.spec.ts
+++ b/packages/backend/src/utils/quadlet-binary-resolver.spec.ts
@@ -17,17 +17,22 @@
  ***********************************************************************/
 
 import { describe, expect, test, vi, beforeEach } from 'vitest';
-import { QuadletBinaryResolver, PODMAN_SYSTEMD_GENERATOR } from './quadlet-binary-resolver';
+import { QuadletBinaryResolver, PODMAN_SYSTEMD_GENERATOR, BINARY_FALLBACK } from './quadlet-binary-resolver';
 import { join } from 'node:path/posix';
-import type { RunResult } from '@podman-desktop/api';
+import type { Logger, RunResult } from '@podman-desktop/api';
 import type { PodmanWorker } from './worker/podman-worker';
 
 const QUADLET_BINARY_PATH_MOCK = '/usr/libexec/podman/quadlet';
 
 const podmanWorkerMock: PodmanWorker = {
   exec: vi.fn(),
-  realPath: vi.fn(),
 } as unknown as PodmanWorker;
+
+const loggerMock: Logger = {
+  log: vi.fn(),
+  error: vi.fn(),
+  warn: vi.fn(),
+};
 
 beforeEach(() => {
   vi.resetAllMocks();
@@ -51,6 +56,12 @@ describe('QuadletBinaryResolver', () => {
             stdout: '/usr/lib/systemd/system-generators',
             command: 'systemd-path',
           };
+        case 'realpath':
+          return {
+            stderr: '',
+            stdout: QUADLET_BINARY_PATH_MOCK,
+            command: 'realpath',
+          };
         // if we try to exec on the quadlet binary return dummy result
         case QUADLET_BINARY_PATH_MOCK:
           return RUN_RESULT_MOCK;
@@ -58,8 +69,6 @@ describe('QuadletBinaryResolver', () => {
           throw new Error(`command ${command} not supported`);
       }
     });
-    vi.mocked(podmanWorkerMock.realPath).mockResolvedValue(QUADLET_BINARY_PATH_MOCK);
-
     const path = await resolver.resolve();
     expect(path).toEqual(QUADLET_BINARY_PATH_MOCK);
 
@@ -67,9 +76,10 @@ describe('QuadletBinaryResolver', () => {
       args: ['systemd-system-generator'],
       token: undefined,
     });
-    expect(podmanWorkerMock.realPath).toHaveBeenCalledWith(
-      join('/usr/lib/systemd/system-generators', PODMAN_SYSTEMD_GENERATOR),
-    );
+    expect(podmanWorkerMock.exec).toHaveBeenCalledWith('realpath', {
+      args: [join('/usr/lib/systemd/system-generators', PODMAN_SYSTEMD_GENERATOR)],
+      token: undefined,
+    });
   });
 
   test('should fail if systemd generator directory is not absolute', async () => {
@@ -81,7 +91,14 @@ describe('QuadletBinaryResolver', () => {
       command: 'systemd-path',
     } as RunResult);
 
-    await expect(resolver.resolve()).rejects.toThrowError('systemd-system-generator directory is not absolute');
+    const result = await resolver.resolve({
+      logger: loggerMock,
+    });
+    expect(result).toEqual(BINARY_FALLBACK);
+    expect(loggerMock.error).toHaveBeenCalledWith(
+      'something went wrong while getting the quadlet binary',
+      new Error('systemd-system-generator directory is not absolute, received "relative/path".'),
+    );
   });
 
   test('should cache on success', async () => {
@@ -96,6 +113,12 @@ describe('QuadletBinaryResolver', () => {
             stdout: '/usr/lib/systemd/system-generators',
             command: 'systemd-path',
           };
+        case 'realpath':
+          return {
+            stderr: '',
+            stdout: QUADLET_BINARY_PATH_MOCK,
+            command: 'realpath',
+          };
         // if we try to exec on the quadlet binary return dummy result
         case QUADLET_BINARY_PATH_MOCK:
           return RUN_RESULT_MOCK;
@@ -103,13 +126,13 @@ describe('QuadletBinaryResolver', () => {
           throw new Error(`command ${command} not supported`);
       }
     });
-    vi.mocked(podmanWorkerMock.realPath).mockResolvedValue(QUADLET_BINARY_PATH_MOCK);
-
     for (let i = 0; i < 10; i++) {
       const path = await resolver.resolve();
       expect(path).toEqual(QUADLET_BINARY_PATH_MOCK);
     }
 
-    expect(podmanWorkerMock.exec).toHaveBeenCalledOnce();
+    // one for systemd-path
+    // one for realpath
+    expect(podmanWorkerMock.exec).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
## Description

Since https://github.com/podman-desktop/extension-podman-quadlet/pull/1108 we use `systemd-path` to determine the location of the quadlet binary. On most systems it is located in `/usr/libexec/podman/quadlet` but there are some systems where it is not.

The problem is, to determine the path, we use `import('node:fs/promise').realpath` but inside a flatpak, the filesystem does not have access to the systemd generators directory, leading to ` ENOENT: no such file or directory`. 

To fix this problem we can use the `exec` method, which internally in Podman Desktop core when it detects it is running inside a flatpak will use `flatpak-spawn` which run on the host and not the flatpak instance.

## Related issues

Fixes https://github.com/podman-desktop/extension-podman-quadlet/issues/1199
Fixes https://github.com/podman-desktop/extension-podman-quadlet/issues/1204

## Testing

**Inside a flatpak**

1. Assert Podman Desktop has been installed using flatpak
2. Start Podman Desktop
3. Go to `Extensions > Install custom`
4. Paste `quay.io/rh-ee-astefani/podman-quadlet-prerelease:1770023505`
5. Assert it is installed properly
6. Go to `Quadlets`
7. Click on `Refresh`
8. The list of Quadlets should appear nicely.