### PR TITLE
chore(ci): use redhat-actions/podman-install GitHub action

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -209,6 +209,7 @@ jobs:
         shell: bash
         run: pnpm test:e2e:smoke
         env:
+          ELECTRON_DISABLE_SANDBOX: '1'
           NODE_OPTIONS: --no-experimental-strip-types
 
       - uses: actions/upload-artifact@v6


### PR DESCRIPTION
## Description

We currently have a lot of custom code to install the latest version of podman in the CI. Let's do some healthy cleanup by using `redhat-actions/podman-install`

## Related issues

Fixes https://github.com/podman-desktop/extension-podman-quadlet/issues/1212

Need rebase after
-  https://github.com/podman-desktop/extension-podman-quadlet/pulls