### PR TITLE
chore(ci): update runner to windows-2025

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -65,7 +65,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [windows-2022, ubuntu-24.04, macos-15]
+        os: [windows-2025, ubuntu-24.04, macos-15]
     steps:
       - uses: actions/checkout@v6
 
@@ -116,7 +116,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ windows-2022, ubuntu-24.04 ]
+        os: [ windows-2025, ubuntu-24.04 ]
     env:
       SKIP_INSTALLATION: true
       EXTENSION_PREINSTALLED: true


### PR DESCRIPTION
## Description

Following discussion with @odockal we need to update the windows runners to 2025 to be able to use the `redhat-actions/podman-install` GitHub action

## Related issues

Fixes https://github.com/podman-desktop/extension-podman-quadlet/issues/1213

Required for
- https://github.com/podman-desktop/extension-podman-quadlet/issues/1212

## Testing

- CI should be :green_circle: 