### PR TITLE
chore(workflow/pr-check): use sha instead of hardcoded version

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -31,12 +31,12 @@ jobs:
     name: linter, formatters
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
         name: Install pnpm
         with:
           run_install: false
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: 24
           cache: 'pnpm'
@@ -67,14 +67,14 @@ jobs:
       matrix:
         os: [windows-2025, ubuntu-24.04, macos-15]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
         name: Install pnpm
         with:
           run_install: false
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: 24
           cache: 'pnpm'
@@ -93,7 +93,7 @@ jobs:
     name: Build Extension Image
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Build Image and Extract Files
         id: build-image
         run: |
@@ -104,7 +104,7 @@ jobs:
           podman rm -f $CONTAINER_ID
           podman rmi -f localhost/local_image:latest
       - name: Upload Quadlet Image Artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: quadlet-plugin
           path: output/plugins/
@@ -124,13 +124,13 @@ jobs:
       # by default playwright cache browsers binaries in ~/.cache/ms-playwright on Linux and %USERPROFILE%\AppData\Local\ms-playwright on Windows
       PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/podman-desktop/pw-browsers
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       # ==============================================
       # Installing Podman
       # ==============================================
       - name: Install Podman
-        uses: redhat-actions/podman-install@main
+        uses: redhat-actions/podman-install@256b8c40fdcb0b494704d72e325ce635d255ff8e
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           ubuntu-version: '24.04'
@@ -138,13 +138,13 @@ jobs:
       # ==============================================
       # Installing Podman Desktop
       # ==============================================
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
         name: Install pnpm
         with:
           run_install: false
 
       # Install Node.js
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: 24
           cache: 'pnpm'
@@ -166,7 +166,7 @@ jobs:
       # Check cache for existing podman-desktop
       - name: Cache Podman Desktop
         id: cache-pd
-        uses: actions/cache@v5
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: ${{ github.workspace }}/podman-desktop
           key: pd-${{ steps.pd-api-version.outputs.PD_VERSION }}-${{ runner.os }}
@@ -200,7 +200,7 @@ jobs:
 
       # Install the quadlet extension
       - name: Download Quadlet Plugins
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: quadlet-plugin
           path: tests/playwright/tests/playwright/output/pd-extension-quadlet-tests/plugins/
@@ -212,7 +212,7 @@ jobs:
           ELECTRON_DISABLE_SANDBOX: '1'
           NODE_OPTIONS: --no-experimental-strip-types
 
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         if: always()
         with:
           name: e2e-pr-check-${{ matrix.os }}


### PR DESCRIPTION
## Description

Update the `.github/workflows/pr-check.yaml` with sha instead of version

## Related issues

Fixes https://github.com/podman-desktop/extension-podman-quadlet/issues/1245