### PR TITLE
feat(podlet-js): support volumes

### DIFF
--- a/packages/podlet-js/src/index.ts
+++ b/packages/podlet-js/src/index.ts
@@ -19,5 +19,6 @@ import { ContainerGenerator } from './containers/container-generator';
 import { ImageGenerator } from './images/image-generator';
 import { Compose } from './compose/compose';
 import { PodGenerator } from './pods/pod-generator';
+import { VolumeGenerator } from './volumes/volume-generator';
 
-export { ImageGenerator, Compose, ContainerGenerator, PodGenerator };
+export { ImageGenerator, Compose, ContainerGenerator, PodGenerator, VolumeGenerator };

--- a/packages/podlet-js/src/models/volume-quadlet.ts
+++ b/packages/podlet-js/src/models/volume-quadlet.ts
@@ -1,0 +1,106 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/**
+ * Learn more about Volume Quadlet https://docs.podman.io/en/latest/markdown/podman-systemd.unit.5.html#volume-units-volume
+ */
+export interface VolumeQuadlet {
+  Volume: {
+    /**
+     * Load the specified containers.conf module.
+     *
+     * Equivalent to the Podman `--module` option.
+     */
+    ContainersConfModule?: Array<string>;
+    /**
+     * If enabled, the content of the image located at the mountpoint of the volume is copied into the volume on the first run.
+     */
+    Copy?: boolean;
+    /**
+     * The path of a device which is mounted for the volume.
+     */
+    Device?: string;
+
+    /**
+     * Specify the volume driver name. When set to image, the Image key must also be set.
+     *
+     * This is equivalent to the Podman --driver option.
+     */
+    Driver?: string;
+    /**
+     * The GID that the volume will be created as. Differently than Group=, the specified value is not passed to the mount operation. The specified GID will own the volume’s mount point directory and affects the volume chown operation.
+     */
+    GID?: string;
+    /**
+     * This key contains a list of arguments passed directly between podman and volume in the generated file. It can be used to access Podman features otherwise unsupported by the generator. Since the generator is unaware of what unexpected interactions can be caused by these arguments, it is not recommended to use this option.
+     *
+     * The format of this is a space separated list of arguments, which can optionally be individually escaped to allow inclusion of whitespace and other control characters.
+     *
+     * This key can be listed multiple times.
+     */
+    GlobalArgs?: Array<string>;
+    /**
+     * The host (numeric) GID, or group name to use as the group for the volume. Differently than GID, the specified value is passed to the mount operation.
+     */
+    Group?: string;
+    /**
+     * Specifies the image the volume is based on when Driver is set to the image. It is recommended to use a fully qualified image name rather than a short name, both for performance and robustness reasons.
+     *
+     * The format of the name is the same as when passed to podman pull. So, it supports using :tag or digests to guarantee the specific image version.
+     *
+     * Special case:
+     *
+     * - If the name of the image ends with .image, Quadlet will use the image pulled by the corresponding .image file, and the generated systemd service contains a dependency on the $name-image.service (or the service name set in the .image file). Note: the corresponding .image file must exist.
+     */
+    Image?: string;
+    /**
+     * Set one or more OCI labels on the volume. The format is a list of key=value items, similar to Environment.
+     *
+     * This key can be listed multiple times.
+     */
+    Label?: Array<string>;
+    /**
+     * The mount options to use for a filesystem as used by the mount(8) command -o option.
+     */
+    Options?: string;
+    /**
+     * This key contains a list of arguments passed directly to the end of the podman volume create command in the generated file (right before the name of the volume in the command line). It can be used to access Podman features otherwise unsupported by the generator. Since the generator is unaware of what unexpected interactions can be caused by these arguments, is not recommended to use this option.
+     *
+     * The format of this is a space separated list of arguments, which can optionally be individually escaped to allow inclusion of whitespace and other control characters.
+     *
+     * This key can be listed multiple times.
+     */
+    PodmanArgs?: Array<string>;
+    /**
+     * The filesystem type of Device as used by the mount(8) commands -t option.
+     */
+    Type?: string;
+    /**
+     * The UID that the volume will be created as. Differently than User, the specified value is not passed to the mount operation. The specified UID will own the volume’s mount point directory and affects the volume chown operation.
+     */
+    UID?: string;
+    /**
+     * The host (numeric) UID, or user name to use as the owner for the volume. Differently than UID, the specified value is passed to the mount operation.
+     */
+    User?: string;
+    /**
+     * The (optional) name of the Podman volume. If this is not specified, the default value is the same name as the unit, but with a systemd- prefix, i.e. a $name.volume file creates a systemd-$name Podman volume to avoid conflicts with user-managed volumes.
+     */
+    VolumeName?: string;
+  };
+}

--- a/packages/podlet-js/src/volumes/tests/device-tmpfs/expect.ini
+++ b/packages/podlet-js/src/volumes/tests/device-tmpfs/expect.ini
@@ -1,0 +1,5 @@
+[Volume]
+VolumeName=myvol
+Device=tmpfs
+Options=nodev,noexec
+Type=tmpfs

--- a/packages/podlet-js/src/volumes/tests/device-tmpfs/volume-inspect.json
+++ b/packages/podlet-js/src/volumes/tests/device-tmpfs/volume-inspect.json
@@ -1,0 +1,13 @@
+{
+  "CreatedAt": "2026-02-16T14:14:31+01:00",
+  "Driver": "local",
+  "Labels": {},
+  "Mountpoint": "/var/lib/containers/storage/volumes/myvol/_data",
+  "Name": "myvol",
+  "Options": {
+    "device": "tmpfs",
+    "o": "nodev,noexec",
+    "type": "tmpfs"
+  },
+  "Scope": "local"
+}

--- a/packages/podlet-js/src/volumes/tests/driver-image/expect.ini
+++ b/packages/podlet-js/src/volumes/tests/driver-image/expect.ini
@@ -1,0 +1,4 @@
+[Volume]
+VolumeName=fedoraVol
+Driver=image
+Image=registry.fedoraproject.org/fedora:latest

--- a/packages/podlet-js/src/volumes/tests/driver-image/volume-inspect.json
+++ b/packages/podlet-js/src/volumes/tests/driver-image/volume-inspect.json
@@ -1,0 +1,11 @@
+{
+  "CreatedAt": "2026-02-16T13:59:51+01:00",
+  "Driver": "image",
+  "Labels": {},
+  "Mountpoint": "",
+  "Name": "fedoraVol",
+  "Options": {
+    "image": "registry.fedoraproject.org/fedora:latest"
+  },
+  "Scope": "local"
+}

--- a/packages/podlet-js/src/volumes/tests/driver-local/expect.ini
+++ b/packages/podlet-js/src/volumes/tests/driver-local/expect.ini
@@ -1,0 +1,2 @@
+[Volume]
+VolumeName=dummy

--- a/packages/podlet-js/src/volumes/tests/driver-local/volume-inspect.json
+++ b/packages/podlet-js/src/volumes/tests/driver-local/volume-inspect.json
@@ -1,0 +1,9 @@
+{
+  "CreatedAt": "2026-02-16T14:12:18+01:00",
+  "Driver": "local",
+  "Labels": {},
+  "Mountpoint": "/var/lib/containers/storage/volumes/dummy/_data",
+  "Name": "dummy",
+  "Options": {},
+  "Scope": "local"
+}

--- a/packages/podlet-js/src/volumes/volume-generator.spec.ts
+++ b/packages/podlet-js/src/volumes/volume-generator.spec.ts
@@ -1,0 +1,46 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import { readdir, readFile, access } from 'node:fs/promises';
+import { join } from 'node:path';
+import { test, expect, describe } from 'vitest';
+import { VolumeGenerator } from './volume-generator';
+
+const assetsDir = join(__dirname, './tests');
+
+describe('generate', async () => {
+  const folders = await readdir(assetsDir);
+
+  test.each(folders)('should generate correct output for %s', async folder => {
+    const folderPath = join(assetsDir, folder);
+    const volumePath = join(folderPath, 'volume-inspect.json');
+    const expectedPath = join(folderPath, 'expect.ini');
+
+    await Promise.all(
+      [volumePath, expectedPath].map(async file => {
+        await access(file);
+      }),
+    );
+
+    const [volume, expected] = await Promise.all([readFile(volumePath, 'utf-8'), readFile(expectedPath, 'utf-8')]);
+
+    const result = new VolumeGenerator({
+      volume: JSON.parse(volume),
+    }).generate();
+    expect(result.trim()).toBe(expected.trim());
+  });
+});

--- a/packages/podlet-js/src/volumes/volume-generator.ts
+++ b/packages/podlet-js/src/volumes/volume-generator.ts
@@ -1,0 +1,76 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { Generator } from '../utils/generator';
+import type { VolumeInfo } from '@podman-desktop/api';
+import { stringify } from 'js-ini';
+import type { VolumeQuadlet } from '../models/volume-quadlet';
+
+interface Dependencies {
+  volume: VolumeInfo;
+}
+
+export class VolumeGenerator extends Generator<Dependencies> {
+  override generate(): string {
+    const volume: VolumeQuadlet = {
+      Volume: {
+        VolumeName: this.dependencies.volume.Name,
+      },
+    };
+
+    switch (this.dependencies.volume.Driver) {
+      case 'local':
+        break; // do nothing local is the default
+      case 'image':
+        if (!this.dependencies.volume.Options?.['image'])
+          throw new Error('driver image must have corresponding image option');
+
+        volume.Volume.Driver = 'image';
+        volume.Volume.Image = this.dependencies.volume.Options?.['image'];
+        break;
+      default:
+        console.warn(`unrecognized driver: ${this.dependencies.volume.Driver}`);
+        volume.Volume.Driver = this.dependencies.volume.Driver;
+    }
+
+    if (this.dependencies.volume.Labels) {
+      const labels = Object.entries(this.dependencies.volume.Labels).map(([key, value]) => `${key}=${value}`);
+      if (labels.length > 0) {
+        volume.Volume.Label = labels;
+      }
+    }
+
+    if (this.dependencies.volume.Options) {
+      const options = this.dependencies.volume.Options;
+      if (options['device']) {
+        volume.Volume.Device = options['device'];
+      }
+      if (options['o']) {
+        volume.Volume.Options = options['o'];
+      }
+      if (options['type']) {
+        volume.Volume.Type = options['type'];
+      }
+      if (options['copy'] === 'true' || options['copy'] === '1') {
+        volume.Volume.Copy = true;
+      }
+    }
+
+    return stringify(this.format(volume));
+  }
+}


### PR DESCRIPTION
## Description

Adding support for generating Volume Quadlet in the `podlet-js` package. A lot of files are fixtures, to test the `VolumeGenerator`.

## Related tests

Part of https://github.com/podman-desktop/extension-podman-quadlet/issues/1163

## Testing

- [x] unit tests have been provided