### PR TITLE
chore(backend): remove unnecessary aliases

### DIFF
--- a/packages/backend/src/apis/pod-api-impl.ts
+++ b/packages/backend/src/apis/pod-api-impl.ts
@@ -15,9 +15,11 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
-import type { ProviderContainerConnectionIdentifierInfo } from '/@shared/src/models/provider-container-connection-identifier-info';
-import { PodApi } from '/@shared/src/apis/pod-api';
-import type { SimplePodInfo } from '/@shared/src/models/simple-pod-info';
+import type {
+  ProviderContainerConnectionIdentifierInfo,
+  SimplePodInfo,
+} from '@podman-desktop/quadlet-extension-core-api';
+import { PodApi } from '@podman-desktop/quadlet-extension-core-api';
 import type { PodService } from '../services/pod-service';
 
 interface Dependencies {

--- a/packages/backend/src/services/pod-service.ts
+++ b/packages/backend/src/services/pod-service.ts
@@ -21,9 +21,11 @@ import type { AsyncInit } from '../utils/async-init';
 import type { EngineHelperDependencies } from './engine-helper';
 import { EngineHelper } from './engine-helper';
 import type { ProviderService } from './provider-service';
-import type { SimplePodInfo } from '/@shared/src/models/simple-pod-info';
+import type {
+  SimplePodInfo,
+  ProviderContainerConnectionIdentifierInfo,
+} from '@podman-desktop/quadlet-extension-core-api';
 import type { ContainerService } from './container-service';
-import type { ProviderContainerConnectionIdentifierInfo } from '/@shared/src/models/provider-container-connection-identifier-info';
 
 interface Dependencies extends EngineHelperDependencies {
   providers: ProviderService;

--- a/packages/backend/tsconfig.json
+++ b/packages/backend/tsconfig.json
@@ -10,9 +10,6 @@
     "allowSyntheticDefaultImports": true,
     "skipLibCheck": true,
     "types": ["node"],
-    "paths": {
-      "/@shared/*": ["../shared/*"]
-    },
     "noImplicitOverride": true,
     "noImplicitReturns": true,
     "noUnusedLocals": true

--- a/packages/backend/vite.config.ts
+++ b/packages/backend/vite.config.ts
@@ -41,8 +41,6 @@ export default defineConfig({
   resolve: {
     alias: {
       '/@/': join(PACKAGE_ROOT, 'src') + '/',
-      '/@gen/': join(PACKAGE_ROOT, 'src-generated') + '/',
-      '/@shared/': join(PACKAGE_ROOT, '../shared') + '/',
     },
   },
   build: {


### PR DESCRIPTION
## Description

Remove the unnecessary aliases in `packages/tsconfig.json` & `packages/vite.config.ts`.

## Related issues

Fixes https://github.com/podman-desktop/extension-podman-quadlet/issues/1257