### PR TITLE
feat(backend): add support for generating network quadlets

### DIFF
--- a/packages/backend/src/apis/network-api-impl.ts
+++ b/packages/backend/src/apis/network-api-impl.ts
@@ -1,0 +1,38 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import {
+  type ProviderContainerConnectionIdentifierInfo,
+  type SimpleNetworkInfo,
+  NetworkApi,
+} from '@podman-desktop/quadlet-extension-core-api';
+import type { NetworkService } from '../services/network-service';
+
+interface Dependencies {
+  networks: NetworkService;
+}
+
+export class NetworkApiImpl extends NetworkApi {
+  constructor(private dependencies: Dependencies) {
+    super();
+  }
+
+  override all(provider: ProviderContainerConnectionIdentifierInfo): Promise<SimpleNetworkInfo[]> {
+    return this.dependencies.networks.all(provider);
+  }
+}

--- a/packages/backend/src/services/main-service.spec.ts
+++ b/packages/backend/src/services/main-service.spec.ts
@@ -46,6 +46,7 @@ import {
   ConfigurationApi,
   PodApi,
   VolumeApi,
+  NetworkApi,
 } from '@podman-desktop/quadlet-extension-core-api';
 import { QuadletApiImpl } from '../apis/quadlet-api-impl';
 import { LoggerApiImpl } from '../apis/logger-api-impl';
@@ -58,6 +59,7 @@ import { DialogApiImpl } from '../apis/dialog-api-impl';
 import { ConfigurationApiImpl } from '../apis/configuration-api-impl';
 import { PodApiImpl } from '../apis/pod-api-impl';
 import { VolumeApiImpl } from '../apis/volume-api-impl';
+import { NetworkApiImpl } from '../apis/network-api-impl';
 
 // mock message-proxy
 vi.mock(import('@podman-desktop/quadlet-extension-core-api'));
@@ -77,6 +79,7 @@ vi.mock(import('./dialog-service'));
 vi.mock(import('./configuration-service'));
 vi.mock(import('./pod-service'));
 vi.mock(import('./volume-service'));
+vi.mock(import('./network-service'));
 
 const EXTENSION_CONTEXT_MOCK: ExtensionContext = {} as unknown as ExtensionContext;
 const WINDOW_API_MOCK: typeof window = {} as unknown as typeof window;
@@ -133,6 +136,7 @@ test('ensure init register all APIs', async () => {
     [ConfigurationApi, ConfigurationApiImpl],
     [PodApi, PodApiImpl],
     [VolumeApi, VolumeApiImpl],
+    [NetworkApi, NetworkApiImpl],
   ]);
 
   for (const [key, value] of APIS.entries()) {

--- a/packages/backend/src/services/network-service.spec.ts
+++ b/packages/backend/src/services/network-service.spec.ts
@@ -1,0 +1,120 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { beforeEach, vi, describe, test, expect } from 'vitest';
+import { NetworkService } from './network-service';
+import type { ProviderService } from './provider-service';
+import type { containerEngine, ProviderContainerConnection, NetworkInspectInfo } from '@podman-desktop/api';
+import type { ProviderContainerConnectionIdentifierInfo } from '@podman-desktop/quadlet-extension-core-api';
+
+const PROVIDER_CONTAINER_CONNECTION_MOCK: ProviderContainerConnection = {
+  connection: {
+    name: 'connection-1',
+    status: vi.fn(),
+    endpoint: {
+      socketPath: '/foo.socket',
+    },
+    type: 'podman',
+  },
+  providerId: 'podman',
+} as unknown as ProviderContainerConnection;
+
+const PROVIDER_SERVICE_MOCK: ProviderService = {
+  getProviderContainerConnection: vi.fn(),
+} as unknown as ProviderService;
+
+const CONTAINER_ENGINE_MOCK: typeof containerEngine = {
+  listNetworks: vi.fn(),
+  listInfos: vi.fn(),
+} as unknown as typeof containerEngine;
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+function getNetworkService(): NetworkService {
+  return new NetworkService({
+    providers: PROVIDER_SERVICE_MOCK,
+    containers: CONTAINER_ENGINE_MOCK,
+  });
+}
+
+describe('NetworkService#all', () => {
+  test('should return filtered networks', async () => {
+    const networkService = getNetworkService();
+
+    const network1: NetworkInspectInfo = {
+      Id: 'network-1',
+      Name: 'network-1',
+      Driver: 'bridge',
+      engineId: 'engine-1',
+    } as unknown as NetworkInspectInfo;
+
+    const network2: NetworkInspectInfo = {
+      Id: 'network-2',
+      Name: 'network-2',
+      Driver: 'bridge',
+      engineId: 'engine-2',
+    } as unknown as NetworkInspectInfo;
+
+    vi.mocked(CONTAINER_ENGINE_MOCK.listNetworks).mockResolvedValue([network1, network2]);
+
+    vi.mocked(PROVIDER_SERVICE_MOCK.getProviderContainerConnection).mockReturnValue(PROVIDER_CONTAINER_CONNECTION_MOCK);
+    vi.mocked(CONTAINER_ENGINE_MOCK.listInfos).mockResolvedValue([
+      { engineId: 'engine-1', engineType: 'podman', engineName: 'Podman' },
+    ]);
+
+    const connectionIdentifier: ProviderContainerConnectionIdentifierInfo = { providerId: 'p1', name: 'connection-1' };
+
+    const result = await networkService.all(connectionIdentifier);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('network-1');
+    expect(result[0].connection).toBe(connectionIdentifier);
+    expect(CONTAINER_ENGINE_MOCK.listNetworks).toHaveBeenCalled();
+    expect(PROVIDER_SERVICE_MOCK.getProviderContainerConnection).toHaveBeenCalledWith(connectionIdentifier);
+  });
+});
+
+describe('NetworkService#inspectNetwork', () => {
+  test('should return network info', async () => {
+    const networkService = getNetworkService();
+
+    const network1: NetworkInspectInfo = {
+      Id: 'network-1',
+      Name: 'network-1',
+      engineId: 'engine-1',
+    } as unknown as NetworkInspectInfo;
+
+    vi.mocked(CONTAINER_ENGINE_MOCK.listNetworks).mockResolvedValue([network1]);
+
+    const result = await networkService.inspectNetwork('engine-1', 'network-1');
+
+    expect(result).toBe(network1);
+  });
+
+  test('should throw error if network not found', async () => {
+    const networkService = getNetworkService();
+
+    vi.mocked(CONTAINER_ENGINE_MOCK.listNetworks).mockResolvedValue([]);
+
+    await expect(networkService.inspectNetwork('engine-1', 'network-1')).rejects.toThrowError(
+      'Network network-1 not found on engine engine-1',
+    );
+  });
+});

--- a/packages/backend/src/services/network-service.ts
+++ b/packages/backend/src/services/network-service.ts
@@ -1,0 +1,76 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { Disposable, NetworkInspectInfo } from '@podman-desktop/api';
+import type { AsyncInit } from '../utils/async-init';
+import type { ProviderService } from './provider-service';
+import { EngineHelper, type EngineHelperDependencies } from './engine-helper';
+import type {
+  ProviderContainerConnectionIdentifierInfo,
+  SimpleNetworkInfo,
+} from '@podman-desktop/quadlet-extension-core-api';
+
+interface Dependencies extends EngineHelperDependencies {
+  providers: ProviderService;
+}
+
+export class NetworkService extends EngineHelper<Dependencies> implements Disposable, AsyncInit {
+  constructor(dependencies: Dependencies) {
+    super(dependencies);
+  }
+
+  async init(): Promise<void> {}
+
+  async all(providerConnection: ProviderContainerConnectionIdentifierInfo): Promise<SimpleNetworkInfo[]> {
+    const networks = await this.dependencies.containers.listNetworks();
+
+    const provider = this.dependencies.providers.getProviderContainerConnection(providerConnection);
+    const engineInfo = await this.getEngineInfo(provider.connection);
+
+    return networks.reduce((output, current) => {
+      // ensure it matches provided connection
+      if (current.engineId === engineInfo.engineId) {
+        output.push(this.toSimpleNetworkInfo(current, providerConnection));
+      }
+      return output;
+    }, [] as SimpleNetworkInfo[]);
+  }
+
+  public async inspectNetwork(engineId: string, networkNameOrId: string): Promise<NetworkInspectInfo> {
+    const networks = await this.dependencies.containers.listNetworks();
+    for (const network of networks) {
+      if (network.engineId !== engineId) continue;
+      if (network.Name === networkNameOrId || network.Id === networkNameOrId) return network;
+    }
+    throw new Error(`Network ${networkNameOrId} not found on engine ${engineId}`);
+  }
+
+  protected toSimpleNetworkInfo(
+    network: NetworkInspectInfo,
+    connection: ProviderContainerConnectionIdentifierInfo,
+  ): SimpleNetworkInfo {
+    return {
+      id: network.Id,
+      name: network.Name,
+      driver: network.Driver,
+      connection,
+    };
+  }
+
+  dispose(): void {}
+}

--- a/packages/backend/src/services/podlet-js-service.spec.ts
+++ b/packages/backend/src/services/podlet-js-service.spec.ts
@@ -29,6 +29,7 @@ import type {
   TelemetryLogger,
   PodInspectInfo,
   VolumeInfo,
+  NetworkInspectInfo,
 } from '@podman-desktop/api';
 import { Compose, ContainerGenerator, ImageGenerator, PodGenerator, VolumeGenerator } from 'podlet-js';
 import { readFile } from 'node:fs/promises';
@@ -39,6 +40,7 @@ import type { ProviderService } from './provider-service';
 import type { PodmanWorker } from '../utils/worker/podman-worker';
 import type { SemVer } from 'semver';
 import type { VolumeService } from './volume-service';
+import type { NetworkService } from './network-service';
 
 /**
  *  mock the podlet-js library
@@ -109,6 +111,10 @@ const VOLUME_INFO_MOCK: VolumeInfo = {
   Name: 'volume-name',
 } as unknown as VolumeInfo;
 
+const NETWORK_INSPECT_MOCK: NetworkInspectInfo = {
+  Name: 'foo',
+} as unknown as NetworkInspectInfo;
+
 const PODMAN_VERSION_MOCK: SemVer = {
   version: '5.0.0',
 } as unknown as SemVer;
@@ -124,6 +130,10 @@ const PROVIDER_SERVICE_MOCK: ProviderService = {
 const VOLUME_SERVICE_MOCK: VolumeService = {
   inspectVolume: vi.fn(),
 } as unknown as VolumeService;
+
+const NETWORK_SERVICE_MOCK: NetworkService = {
+  inspectNetwork: vi.fn(),
+} as unknown as NetworkService;
 
 const CONTAINER_GENERATE_OUTPUT: string = 'container-quadlet-content';
 const IMAGE_GENERATE_OUTPUT: string = 'image-quadlet-content';
@@ -150,6 +160,9 @@ beforeEach(() => {
   // mock volume service
   vi.mocked(VOLUME_SERVICE_MOCK.inspectVolume).mockResolvedValue(VOLUME_INFO_MOCK);
 
+  // mock network service
+  vi.mocked(NETWORK_SERVICE_MOCK.inspectNetwork).mockResolvedValue(NETWORK_INSPECT_MOCK);
+
   // mock provider service
   vi.mocked(PROVIDER_SERVICE_MOCK.getProviderContainerConnection).mockReturnValue(PROVIDER_CONTAINER_CONNECTION_MOCK);
   vi.mocked(PODMAN_SERVICE_MOCK.getWorker).mockResolvedValue(PODMAN_WORKER_MOCK);
@@ -165,6 +178,7 @@ function getService(): PodletJsService {
     podman: PODMAN_SERVICE_MOCK,
     providers: PROVIDER_SERVICE_MOCK,
     volumes: VOLUME_SERVICE_MOCK,
+    networks: NETWORK_SERVICE_MOCK,
   });
 }
 

--- a/packages/shared/src/apis/network-api.ts
+++ b/packages/shared/src/apis/network-api.ts
@@ -1,0 +1,25 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import type { SimpleNetworkInfo } from '../models/simple-network-info';
+import type { ProviderContainerConnectionIdentifierInfo } from '../models/provider-container-connection-identifier-info';
+
+export abstract class NetworkApi {
+  static readonly CHANNEL: string = 'network-api';
+
+  abstract all(provider: ProviderContainerConnectionIdentifierInfo): Promise<SimpleNetworkInfo[]>;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -28,6 +28,7 @@ export * from './apis/quadlet-api';
 export * from './apis/routing-api';
 export * from './apis/pod-api';
 export * from './apis/volume-api';
+export * from './apis/network-api';
 
 // export messaging logic
 export * from './messages/message-proxy';
@@ -50,6 +51,7 @@ export * from './models/template-instance-quadlet';
 export * from './models/template-quadlet';
 export * from './models/simple-pod-info';
 export * from './models/simple-volume-info';
+export * from './models/simple-network-info';
 
 // export utility enums & constants
 export * from './utils/quadlet-type';

--- a/packages/shared/src/models/simple-network-info.ts
+++ b/packages/shared/src/models/simple-network-info.ts
@@ -1,0 +1,25 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import type { ProviderContainerConnectionIdentifierInfo } from './provider-container-connection-identifier-info';
+
+export interface SimpleNetworkInfo {
+  id: string;
+  name: string;
+  driver: string;
+  connection: ProviderContainerConnectionIdentifierInfo;
+}


### PR DESCRIPTION
## Description

Following https://github.com/podman-desktop/extension-podman-quadlet/pull/1269 we can now add the implementation for the backend part.

## Related issues

Part of https://github.com/podman-desktop/extension-podman-quadlet/issues/1160

## Testing

Full feature can be tested in https://github.com/podman-desktop/extension-podman-quadlet/pull/1264