### PR TITLE
fix: unplugin-dts version alignment

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "vite": "^8.0.8",
-    "vite-plugin-dts": "^4.3.0",
+    "vite-plugin-dts": "^4.5.4",
     "vitest": "^4.0.10",
     "@podman-desktop/api": "^1.26.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -319,7 +319,7 @@ importers:
         specifier: ^8.0.8
         version: 8.0.8(@types/node@24.10.9)(esbuild@0.27.2)(jiti@2.6.1)(yaml@2.6.1)
       vite-plugin-dts:
-        specifier: ^4.3.0
+        specifier: ^4.5.4
         version: 4.5.4(@types/node@24.10.9)(rollup@4.55.1)(typescript@5.9.3)(vite@8.0.8(@types/node@24.10.9)(esbuild@0.27.2)(jiti@2.6.1)(yaml@2.6.1))
       vitest:
         specifier: ^4.0.10


### PR DESCRIPTION
## Description

Noticed that the version was not the same between `packages/podlet-js` and `packages/shared`

https://github.com/podman-desktop/extension-podman-quadlet/blob/529d935323441989ab37df95cca6be726511f86a/packages/podlet-js/package.json#L20

## Related issues

Trying to address https://github.com/redhat-developer/podman-desktop-hummingbird-ext/security/dependabot/55