### PR TITLE
chore(dependabot): adding vitest rule for updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,3 +31,8 @@ updates:
         applies-to: version-updates
         patterns:
           - "@xterm/*"
+      vitest:
+        applies-to: version-updates
+        patterns:
+          - "@vitest/*"
+          - "vitest"


### PR DESCRIPTION
## Description

As requested in https://github.com/podman-desktop/extension-podman-quadlet/pull/1389#issuecomment-4223802725 adding a rule for dependabot vitest group updates