### PR TITLE
chore(ci): publish-oci-pr.yaml

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -87,3 +87,15 @@ jobs:
 
       - name: Run unit tests
         run: pnpm test:unit
+
+  build-oci:
+    name: build oci image
+    runs-on: ubuntu-24.04
+    outputs:
+      artifact-id: ${{ steps.build.outputs.artifact-id }}
+    steps:
+      - name: Build OCI
+        id: build
+        uses: podman-desktop/gh-extensions-actions/.github/actions/oci-build@2e7a02e8c8e9256a2fa466fb166e215175130dd7 # v0.1.2
+        with:
+          ref: ${{ github.ref }}

--- a/.github/workflows/publish-oci-pr.yaml
+++ b/.github/workflows/publish-oci-pr.yaml
@@ -1,0 +1,46 @@
+#
+# Copyright (C) 2026 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: publish-oci-pr
+
+on:
+  workflow_run:
+    workflows:
+      - 'pr-check'
+    types:
+      - completed
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    uses: podman-desktop/gh-extensions-actions/.github/workflows/publish-oci-pr.yml@0dfd06899ce71f9a469ac745e97f8449d42529bb
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+      actions: read
+      packages: write
+      checks: write
+    with:
+      run-id: ${{ github.event.workflow_run.id }}
+      head-sha: ${{ github.event.workflow_run.head_sha }}
+      image-name: ${{ github.repository }}
+    secrets:
+      registry-password: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

Adding the required logic to build & push the OCI image of the PR in a secure manner.

## Related issues

Fixes https://github.com/podman-desktop/extension-podman-quadlet/issues/1416