### PR TITLE
chore(ci): modernize e2e workflow

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -133,7 +133,7 @@ jobs:
         env:
           ELECTRON_DISABLE_SANDBOX: '1'
           NODE_OPTIONS: --no-experimental-strip-types
-          DEBUGGING_PORT: 2222
+          DEBUGGING_PORT: 9222
           PODMAN_DESKTOP_BINARY: ${{ env.PODMAN_DESKTOP_BINARY }}
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -63,9 +63,6 @@ jobs:
     env:
       SKIP_INSTALLATION: true
       EXTENSION_PREINSTALLED: true
-      PODMAN_DESKTOP_ARGS: ${{ github.workspace }}/podman-desktop
-      # by default playwright cache browsers binaries in ~/.cache/ms-playwright on Linux and %USERPROFILE%\AppData\Local\ms-playwright on Windows
-      PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/podman-desktop/pw-browsers
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -106,40 +103,22 @@ jobs:
           echo "PD_VERSION=$PD_VERSION" >> $GITHUB_OUTPUT
           echo "Using @podman-desktop/api $PD_VERSION"
 
-      # Check cache for existing podman-desktop
-      - name: Cache Podman Desktop
-        id: cache-pd
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ${{ github.workspace }}/podman-desktop
-          key: pd-${{ steps.pd-api-version.outputs.PD_VERSION }}-${{ runner.os }}
-
-      # Download Podman Desktop repository based on version defined in package.json
+      # Download Podman Desktop binary
       - name: Download Podman Desktop
-        if: steps.cache-pd.outputs.cache-hit != 'true'
         shell: bash
         env:
           PD_VERSION: ${{ steps.pd-api-version.outputs.PD_VERSION }}
         run: |
-          echo "Downloading PD desktop to ${{ github.workspace }}/podman-desktop"
-          # Stable release are available podman-desktop/podman-desktop
-          # Prerelease are available under podman-desktop/prereleases
-          if [[ "$PD_VERSION" =~ - ]]; then
-            curl -sL "https://github.com/podman-desktop/prereleases/archive/refs/tags/v$PD_VERSION.tar.gz" | tar xvz
+          echo "Downloading PD desktop $PD_VERSION"
+          if [[ "${{ runner.os }}" == "Linux" ]]; then
+            curl -sL "https://github.com/podman-desktop/podman-desktop/releases/download/v$PD_VERSION/podman-desktop-$PD_VERSION-x64.tar.gz" -o podman-desktop.tar.gz
+            mkdir podman-desktop-dir
+            tar -xzf podman-desktop.tar.gz -C podman-desktop-dir --strip-components=1
+            echo "PODMAN_DESKTOP_BINARY=$(pwd)/podman-desktop-dir/podman-desktop" >> $GITHUB_ENV
           else
-            curl -sL "https://github.com/podman-desktop/podman-desktop/archive/refs/tags/v$PD_VERSION.tar.gz" | tar xvz
+            curl -sL "https://github.com/podman-desktop/podman-desktop/releases/download/v$PD_VERSION/podman-desktop-$PD_VERSION-x64.exe" -o podman-desktop.exe
+            echo "PODMAN_DESKTOP_BINARY=$(pwd)/podman-desktop.exe" >> $GITHUB_ENV
           fi
-          # Move the extracted folder to the podman-desktop folder
-          mv podman-desktop-$PD_VERSION/ podman-desktop/
-
-      # Install and build podman-desktop
-      - name: Install pnpm deps and build Podman Desktop
-        if: steps.cache-pd.outputs.cache-hit != 'true'
-        shell: bash
-        working-directory: ${{ github.workspace }}/podman-desktop
-        run: |
-          pnpm install
-          pnpm test:e2e:build
 
       # Install the quadlet extension
       - name: Download Quadlet Plugins
@@ -154,6 +133,8 @@ jobs:
         env:
           ELECTRON_DISABLE_SANDBOX: '1'
           NODE_OPTIONS: --no-experimental-strip-types
+          DEBUGGING_PORT: 2222
+          PODMAN_DESKTOP_BINARY: ${{ env.PODMAN_DESKTOP_BINARY }}
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -63,9 +63,6 @@ jobs:
     env:
       SKIP_INSTALLATION: true
       EXTENSION_PREINSTALLED: true
-      PODMAN_DESKTOP_ARGS: ${{ github.workspace }}/podman-desktop
-      # by default playwright cache browsers binaries in ~/.cache/ms-playwright on Linux and %USERPROFILE%\AppData\Local\ms-playwright on Windows
-      PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/podman-desktop/pw-browsers
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -106,40 +103,22 @@ jobs:
           echo "PD_VERSION=$PD_VERSION" >> $GITHUB_OUTPUT
           echo "Using @podman-desktop/api $PD_VERSION"
 
-      # Check cache for existing podman-desktop
-      - name: Cache Podman Desktop
-        id: cache-pd
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ${{ github.workspace }}/podman-desktop
-          key: pd-${{ steps.pd-api-version.outputs.PD_VERSION }}-${{ runner.os }}
-
-      # Download Podman Desktop repository based on version defined in package.json
+      # Download Podman Desktop binary
       - name: Download Podman Desktop
-        if: steps.cache-pd.outputs.cache-hit != 'true'
         shell: bash
         env:
           PD_VERSION: ${{ steps.pd-api-version.outputs.PD_VERSION }}
         run: |
-          echo "Downloading PD desktop to ${{ github.workspace }}/podman-desktop"
-          # Stable release are available podman-desktop/podman-desktop
-          # Prerelease are available under podman-desktop/prereleases
-          if [[ "$PD_VERSION" =~ - ]]; then
-            curl -sL "https://github.com/podman-desktop/prereleases/archive/refs/tags/v$PD_VERSION.tar.gz" | tar xvz
+          echo "Downloading PD desktop $PD_VERSION"
+          if [[ "${{ runner.os }}" == "Linux" ]]; then
+            curl -sL "https://github.com/podman-desktop/podman-desktop/releases/download/v$PD_VERSION/podman-desktop-$PD_VERSION-x64.tar.gz" -o podman-desktop.tar.gz
+            mkdir podman-desktop-dir
+            tar -xzf podman-desktop.tar.gz -C podman-desktop-dir --strip-components=1
+            echo "PODMAN_DESKTOP_BINARY=$(pwd)/podman-desktop-dir/podman-desktop" >> $GITHUB_ENV
           else
-            curl -sL "https://github.com/podman-desktop/podman-desktop/archive/refs/tags/v$PD_VERSION.tar.gz" | tar xvz
+            curl -sL "https://github.com/podman-desktop/podman-desktop/releases/download/v$PD_VERSION/podman-desktop-$PD_VERSION-x64.exe" -o podman-desktop.exe
+            echo "PODMAN_DESKTOP_BINARY=$(pwd)/podman-desktop.exe" >> $GITHUB_ENV
           fi
-          # Move the extracted folder to the podman-desktop folder
-          mv podman-desktop-$PD_VERSION/ podman-desktop/
-
-      # Install and build podman-desktop
-      - name: Install pnpm deps and build Podman Desktop
-        if: steps.cache-pd.outputs.cache-hit != 'true'
-        shell: bash
-        working-directory: ${{ github.workspace }}/podman-desktop
-        run: |
-          pnpm install
-          pnpm test:e2e:build
 
       # Install the quadlet extension
       - name: Download Quadlet Plugins
@@ -154,6 +133,8 @@ jobs:
         env:
           ELECTRON_DISABLE_SANDBOX: '1'
           NODE_OPTIONS: --no-experimental-strip-types
+          DEBUGGING_PORT: 2222
+          PODMAN_DESKTOP_BINARY: ${{ env.PODMAN_DESKTOP_BINARY }}
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -118,15 +118,15 @@ jobs:
 
       - name: Download and Install Podman Desktop (Windows)
         if: runner.os == 'Windows'
-        shell: bash
+        shell: pwsh
         env:
           PD_VERSION: ${{ steps.pd-api-version.outputs.PD_VERSION }}
         run: |
-          echo "Downloading PD desktop $PD_VERSION for Windows"
-          curl -sL "https://github.com/podman-desktop/podman-desktop/releases/download/v$PD_VERSION/podman-desktop-$PD_VERSION-setup-x64.exe" -o podman-desktop-setup.exe
-          ./podman-desktop-setup.exe /S
-          PD_INSTALL_DIR="$LOCALAPPDATA/Programs/Podman Desktop"
-          echo "PODMAN_DESKTOP_BINARY=$PD_INSTALL_DIR/Podman Desktop.exe" >> $GITHUB_ENV
+          Write-Host "Downloading PD desktop $env:PD_VERSION for Windows"
+          curl.exe -sL "https://github.com/podman-desktop/podman-desktop/releases/download/v$env:PD_VERSION/podman-desktop-$env:PD_VERSION-setup-x64.exe" -o podman-desktop-setup.exe
+          Start-Process -FilePath .\podman-desktop-setup.exe -ArgumentList '/S' -Wait
+          $binary = "$env:LOCALAPPDATA\Programs\Podman Desktop\Podman Desktop.exe"
+          echo "PODMAN_DESKTOP_BINARY=$binary" >> $env:GITHUB_ENV
 
       # Install the quadlet extension
       - name: Download Quadlet Plugins

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -104,21 +104,29 @@ jobs:
           echo "Using @podman-desktop/api $PD_VERSION"
 
       # Download Podman Desktop binary
-      - name: Download Podman Desktop
+      - name: Download Podman Desktop (Linux)
+        if: runner.os == 'Linux'
         shell: bash
         env:
           PD_VERSION: ${{ steps.pd-api-version.outputs.PD_VERSION }}
         run: |
-          echo "Downloading PD desktop $PD_VERSION"
-          if [[ "${{ runner.os }}" == "Linux" ]]; then
-            curl -sL "https://github.com/podman-desktop/podman-desktop/releases/download/v$PD_VERSION/podman-desktop-$PD_VERSION-x64.tar.gz" -o podman-desktop.tar.gz
-            mkdir podman-desktop-dir
-            tar -xzf podman-desktop.tar.gz -C podman-desktop-dir --strip-components=1
-            echo "PODMAN_DESKTOP_BINARY=$(pwd)/podman-desktop-dir/podman-desktop" >> $GITHUB_ENV
-          else
-            curl -sL "https://github.com/podman-desktop/podman-desktop/releases/download/v$PD_VERSION/podman-desktop-$PD_VERSION-x64.exe" -o podman-desktop.exe
-            echo "PODMAN_DESKTOP_BINARY=$(pwd)/podman-desktop.exe" >> $GITHUB_ENV
-          fi
+          echo "Downloading PD desktop $PD_VERSION for Linux"
+          curl -sL "https://github.com/podman-desktop/podman-desktop/releases/download/v$PD_VERSION/podman-desktop-$PD_VERSION-x64.tar.gz" -o podman-desktop.tar.gz
+          mkdir podman-desktop-dir
+          tar -xzf podman-desktop.tar.gz -C podman-desktop-dir --strip-components=1
+          echo "PODMAN_DESKTOP_BINARY=$(pwd)/podman-desktop-dir/podman-desktop" >> $GITHUB_ENV
+
+      - name: Download and Install Podman Desktop (Windows)
+        if: runner.os == 'Windows'
+        shell: bash
+        env:
+          PD_VERSION: ${{ steps.pd-api-version.outputs.PD_VERSION }}
+        run: |
+          echo "Downloading PD desktop $PD_VERSION for Windows"
+          curl -sL "https://github.com/podman-desktop/podman-desktop/releases/download/v$PD_VERSION/podman-desktop-$PD_VERSION-setup-x64.exe" -o podman-desktop-setup.exe
+          ./podman-desktop-setup.exe /S
+          PD_INSTALL_DIR="$LOCALAPPDATA/Programs/Podman Desktop"
+          echo "PODMAN_DESKTOP_BINARY=$PD_INSTALL_DIR/Podman Desktop.exe" >> $GITHUB_ENV
 
       # Install the quadlet extension
       - name: Download Quadlet Plugins

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -103,30 +103,13 @@ jobs:
           echo "PD_VERSION=$PD_VERSION" >> $GITHUB_OUTPUT
           echo "Using @podman-desktop/api $PD_VERSION"
 
-      # Download Podman Desktop binary
-      - name: Download Podman Desktop (Linux)
-        if: runner.os == 'Linux'
-        shell: bash
-        env:
-          PD_VERSION: ${{ steps.pd-api-version.outputs.PD_VERSION }}
-        run: |
-          echo "Downloading PD desktop $PD_VERSION for Linux"
-          curl -sL "https://github.com/podman-desktop/podman-desktop/releases/download/v$PD_VERSION/podman-desktop-$PD_VERSION-x64.tar.gz" -o podman-desktop.tar.gz
-          mkdir podman-desktop-dir
-          tar -xzf podman-desktop.tar.gz -C podman-desktop-dir --strip-components=1
-          echo "PODMAN_DESKTOP_BINARY=$(pwd)/podman-desktop-dir/podman-desktop" >> $GITHUB_ENV
-
-      - name: Download and Install Podman Desktop (Windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        env:
-          PD_VERSION: ${{ steps.pd-api-version.outputs.PD_VERSION }}
-        run: |
-          Write-Host "Downloading PD desktop $env:PD_VERSION for Windows"
-          curl.exe -sL "https://github.com/podman-desktop/podman-desktop/releases/download/v$env:PD_VERSION/podman-desktop-$env:PD_VERSION-setup-x64.exe" -o podman-desktop-setup.exe
-          Start-Process -FilePath .\podman-desktop-setup.exe -ArgumentList '/S' -Wait
-          $binary = "$env:LOCALAPPDATA\Programs\Podman Desktop\Podman Desktop.exe"
-          echo "PODMAN_DESKTOP_BINARY=$binary" >> $env:GITHUB_ENV
+      # Download and install the Podman Desktop production binary (Linux & Windows)
+      - name: Install Podman Desktop
+        id: podman-desktop-install
+        uses: podman-desktop/gh-extensions-actions/.github/actions/podman-desktop-install@0abcba929bec797400b7fc1d6229f2907e1d4c1d # v0.2.0
+        with:
+          version: ${{ steps.pd-api-version.outputs.PD_VERSION }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       # Install the quadlet extension
       - name: Download Quadlet Plugins
@@ -142,7 +125,7 @@ jobs:
           ELECTRON_DISABLE_SANDBOX: '1'
           NODE_OPTIONS: --no-experimental-strip-types
           DEBUGGING_PORT: 9222
-          PODMAN_DESKTOP_BINARY: ${{ env.PODMAN_DESKTOP_BINARY }}
+          PODMAN_DESKTOP_BINARY: ${{ steps.podman-desktop-install.outputs.binary }}
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()

--- a/tests/playwright/src/quadlet-extension.spec.ts
+++ b/tests/playwright/src/quadlet-extension.spec.ts
@@ -29,6 +29,7 @@ test.use({
      * For performance reasons, disable extensions which are not necessary for the e2e
      */
     customSettings: {
+      'update.reminder': 'never',
       'extensions.disabled': [
         'podman-desktop.compose',
         'podman-desktop.docker',

--- a/tests/playwright/src/quadlet-extension.spec.ts
+++ b/tests/playwright/src/quadlet-extension.spec.ts
@@ -29,7 +29,7 @@ test.use({
      * For performance reasons, disable extensions which are not necessary for the e2e
      */
     customSettings: {
-      'update.reminder': 'never',
+      'preferences.update.reminder': 'never',
       'extensions.disabled': [
         'podman-desktop.compose',
         'podman-desktop.docker',


### PR DESCRIPTION
## Description

Following https://github.com/podman-desktop/extension-podman-quadlet/pull/1390 we can simplify (by a lot the e2e logic) as we no longer need to download and build with some special flag the Podman Desktop executable, we can directly download it from the release.

To avoid duplicating the logic of downloading and installing Podman Desktop in every extension we created a composite GitHub action (See https://github.com/podman-desktop/gh-extensions-actions/pull/15) to do this step for us.