### PR TITLE
chore(ci): reuse existing oci image

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -59,17 +59,37 @@ jobs:
           github-token: ${{ secrets.github-token }}
           path: .
 
-      - name: Extract Files
-        id: extract-image
+      - name: Load image
+        id: load-image
+        shell: bash
         run: |
-          mkdir ./extracted
-          tar -xf oci-image.tar -C ./extracted
+          set -euo pipefail
+          
+          OUTPUT=$(podman load -i oci-image.tar)
+          echo "$OUTPUT"
+          
+          IMAGE=$(echo "$OUTPUT" | awk -F': ' '/Loaded image:/ {print $2}' | tail -n1)
+          
+          if [ -z "$IMAGE" ]; then
+          echo "❌ Failed to determine loaded image name"
+          exit 1
+          fi
+          
+          echo "image=$IMAGE" >> "$GITHUB_OUTPUT"
+
+      - name: Build Image and Extract Files
+        id: build-image
+        run: |
+          CONTAINER_ID=$(podman create "${{ steps.load-image.outputs.image }}" --entrypoint "")
+          mkdir -p output/plugins
+          podman export $CONTAINER_ID | tar -x -C output/plugins/
+          podman rm -f $CONTAINER_ID
 
       - name: Upload Quadlet Image Artifact
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: quadlet-plugin
-          path: ./extracted
+          path: output/plugins/
 
   e2e:
     name: e2e tests smoke / ${{ matrix.os }}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -18,10 +18,26 @@
 name: e2e
 
 on:
-  pull_request:
-  push:
-    branches:
-      - main
+  workflow_call:
+    inputs:
+      run-id:
+        required: true
+        description: 'The id of the workflow run where the desired download artifact was uploaded from.'
+        type: string
+        default: '${{ github.run_id }}'
+
+      artifact-id:
+        required: false
+        description: 'The id of the artifact to publish'
+        type: string
+
+      artifact-name:
+        required: false
+        description: 'The id of the artifact to publish'
+        type: string
+    secrets:
+      github-token:
+        required: true
 
 permissions:
   contents: read
@@ -31,31 +47,34 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Dedicated step to build the quadlet extension image
-  build-container:
-    name: Build Extension Image
+  download-oci:
+    name: extract oci image
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Build Image and Extract Files
-        id: build-image
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          run-id: ${{ inputs.run-id }}
+          name: ${{ inputs.artifact-name }}
+          artifact-ids: ${{ inputs.artifact-id }}
+          github-token: ${{ secrets.github-token }}
+          path: .
+
+      - name: Extract Files
+        id: extract-image
         run: |
-          podman build -t local_image ./
-          CONTAINER_ID=$(podman create localhost/local_image --entrypoint "")
-          mkdir -p output/plugins
-          podman export $CONTAINER_ID | tar -x -C output/plugins/
-          podman rm -f $CONTAINER_ID
-          podman rmi -f localhost/local_image:latest
+          mkdir ./extracted
+          tar -xf oci-image.tar -C ./extracted
+
       - name: Upload Quadlet Image Artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: quadlet-plugin
-          path: output/plugins/
+          path: ./extracted
 
   e2e:
     name: e2e tests smoke / ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    needs: build-container
+    needs: download-oci
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/next.yaml
+++ b/.github/workflows/next.yaml
@@ -1,0 +1,46 @@
+#
+# Copyright (C) 2026 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: next
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  oci-build:
+    runs-on: ubuntu-24.04
+    outputs:
+      artifact-id: ${{ steps.build.outputs.artifact-id }}
+    steps:
+      - uses: podman-desktop/gh-extensions-actions/.github/actions/oci-build@2e7a02e8c8e9256a2fa466fb166e215175130dd7 # v0.1.2
+        id: build
+        with:
+          ref: ${{ github.ref }}
+
+  e2e:
+    needs: oci-build
+    uses: ./.github/workflows/e2e.yaml
+    with:
+      artifact-id: ${{ needs.oci-build.outputs.artifact-id }}
+      run-id: ${{ github.run_id }}
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2024-2025 Red Hat, Inc.
+# Copyright (C) 2024-2026 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -99,3 +99,12 @@ jobs:
         uses: podman-desktop/gh-extensions-actions/.github/actions/oci-build@2e7a02e8c8e9256a2fa466fb166e215175130dd7 # v0.1.2
         with:
           ref: ${{ github.ref }}
+
+  e2e:
+    needs: build-oci
+    uses: ./.github/workflows/e2e.yaml
+    with:
+      artifact-id: ${{ needs.oci-build.outputs.artifact-id }}
+      run-id: ${{ github.run_id }}
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

Since https://github.com/podman-desktop/extension-podman-quadlet/pull/1417 the pr-check is building the oci-image before publishing it through `publish-oci-pr.yaml`.

But the e2e was also building the image, so we were doing twice the work. Instead let's reuse the oci image already build.