### PR TITLE
fix(backend): quadlet parsing logic

### DIFF
--- a/packages/backend/src/utils/parsers/quadlet-dryrun-parser.spec.ts
+++ b/packages/backend/src/utils/parsers/quadlet-dryrun-parser.spec.ts
@@ -22,6 +22,7 @@ import TEMPLATE_AND_INSTANCE from '/@/utils/parsers/tests/quadlet-stdout-templat
 import MULTIPLE_QUADLETS_EXAMPLE from '/@/utils/parsers/tests/quadlet-stdout-multiple-quadlets.txt?raw';
 import DRYRUN_STDERR from '/@/utils/parsers/tests/quadlet-stderr.txt?raw';
 import TEMPLATE_QUADLET from '/@/utils/parsers/tests/quadlet-stdout-container-template.txt?raw';
+import QUADLET_WITH_COMMENTS from '/@/utils/parsers/tests/quadlet-stdout-with-comments.txt?raw';
 import {
   isTemplateQuadlet,
   isServiceQuadlet,
@@ -128,4 +129,21 @@ test('expect template and instance quadlet to be recognised', async () => {
   // an instance is not a template
   expect(isTemplateQuadlet(instance)).toBeFalsy();
   expect(isTemplateInstanceQuadlet(instance)).toBeTruthy();
+});
+
+test('expect quadlet with section comments containing --- to be parsed correctly', async () => {
+  const parser = new QuadletDryRunParser({
+    stdout: QUADLET_WITH_COMMENTS,
+    stderr: '',
+    command: '',
+  });
+
+  const result = parser.parse();
+  expect(result).toHaveLength(1);
+
+  const [quadlet] = result;
+
+  assert(isServiceQuadlet(quadlet));
+
+  expect(quadlet.service).toBe('socket-proxy.service');
 });

--- a/packages/backend/src/utils/parsers/quadlet-dryrun-parser.ts
+++ b/packages/backend/src/utils/parsers/quadlet-dryrun-parser.ts
@@ -28,18 +28,34 @@ export class QuadletDryRunParser extends Parser<RunResult & { exitCode?: number 
   }
 
   protected parseStdout(): Quadlet[] {
-    // Regular expression to match the structure of the content
-    // eslint-disable-next-line sonarjs/slow-regex
-    const serviceRegex = /---(.*?)---\n([\s\S]*?)(?=---|$)/g;
-    let match;
+    const lines = this.content.stdout.split(/\r?\n/);
+    const regex = RegExp(/^---([^\r\n]+\.service)---$/);
 
-    while ((match = serviceRegex.exec(this.content.stdout))) {
-      const serviceName = match[1].trim();
+    let buffer: string | undefined = undefined;
+    let serviceName: string | undefined = undefined;
 
-      // parse the quadlet unit
-      const quadletUnitParser = new QuadletUnitParser(serviceName, match[2].trim());
-      this.services[serviceName] = quadletUnitParser.parse();
+    const flush = (): void => {
+      if (!serviceName || !buffer) {
+        return;
+      }
+
+      this.services[serviceName] = new QuadletUnitParser(serviceName, buffer).parse();
+      serviceName = undefined;
+      buffer = undefined;
+    };
+
+    for (const line of lines) {
+      const match = regex.exec(line);
+      if (match) {
+        flush();
+
+        serviceName = match[1].trim();
+        buffer = undefined;
+      } else {
+        buffer = buffer ? buffer + '\n' + line : line;
+      }
     }
+    flush();
 
     this.parsed = true;
     return Object.values(this.services);

--- a/packages/backend/src/utils/parsers/quadlet-dryrun-parser.ts
+++ b/packages/backend/src/utils/parsers/quadlet-dryrun-parser.ts
@@ -52,7 +52,7 @@ export class QuadletDryRunParser extends Parser<RunResult & { exitCode?: number 
         serviceName = match[1].trim();
         buffer = undefined;
       } else {
-        buffer = buffer ? buffer + '\n' + line : line;
+        buffer = buffer ? `${buffer}\n${line}` : line;
       }
     }
     flush();

--- a/packages/backend/src/utils/parsers/tests/quadlet-stdout-with-comments.txt
+++ b/packages/backend/src/utils/parsers/tests/quadlet-stdout-with-comments.txt
@@ -1,0 +1,31 @@
+---socket-proxy.service---
+[Unit]
+Wants=network-online.target
+After=network-online.target
+SourcePath=/home/user/.config/containers/systemd/socket-proxy.container
+RequiresMountsFor=%t/containers
+
+[X-Container]
+# --- Primary Properties ---
+Image=lscr.io/linuxserver/socket-proxy:latest
+ContainerName=socket-proxy_authentik
+ReadOnly=true
+
+# --- Storage & Mounts ---
+Tmpfs=/run
+Volume=/run/user/1000/podman/podman.sock:/var/run/docker.sock:ro,z
+
+[Service]
+Restart=always
+Environment=PODMAN_SYSTEMD_UNIT=%n
+KillMode=mixed
+ExecStop=/usr/bin/podman rm -v -f -i --cidfile=%t/%N.cid
+ExecStopPost=-/usr/bin/podman rm -v -f -i --cidfile=%t/%N.cid
+Delegate=yes
+Type=notify
+NotifyAccess=all
+SyslogIdentifier=%N
+ExecStart=/usr/bin/podman run --name=socket-proxy_authentik --cidfile=%t/%N.cid --replace --rm --cgroups=split --sdnotify=conmon -d --read-only --tmpfs /run --volume /run/user/1000/podman/podman.sock:/var/run/docker.sock:ro,z lscr.io/linuxserver/socket-proxy:latest
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
## Description

Update the way we parse quadlets dryrun output to be more robust.

## Related issues

Fixes https://github.com/podman-desktop/extension-podman-quadlet/issues/1425

## Testing

- [x] unit tests ensure no regression

> Regression test has been added