### PR TITLE
fix(frontend): show monaco editor when quadlet content is empty

### DIFF
--- a/packages/frontend/src/pages/QuadletDetails.svelte
+++ b/packages/frontend/src/pages/QuadletDetails.svelte
@@ -218,7 +218,7 @@ function onchange(content: string): void {
               <ErrorMessage error={quadletSourceError} />
             {/if}
           </div>
-          {#if quadletSource}
+          {#if quadletSource !== undefined}
             <EditorOverlay save={save} loading={loading} changed={changed} />
             <MonacoEditor class="h-full" onChange={onchange} content={quadletSource} language="ini" />
           {/if}


### PR DESCRIPTION
### What does this PR do?

Fixes the condition that controls MonacoEditor visibility on the QuadletDetails source tab. The previous check `{#if quadletSource}` treated an empty string as false, hiding the editor. Changed to `{#if quadletSource !== undefined}` so the editor renders even when quadlet content is empty.

### What issues does this PR fix or reference?

Closes #1302 