### PR TITLE
chore(pnpm): set minimumReleaseAge to v11 default

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
 packages:
   - 'packages/*'
   - 'tests/*'
+
+minimumReleaseAge: 1440


### PR DESCRIPTION
## Description

pnpm v11 is using minimumReleaseAge to 1440. We need to merge this first to prevent dependabot to update dependencies as the migration to pnpm v11 will fail otherwise