### PR TITLE
fix: update to `@podman-desktop/*` 1.28.2

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -76,7 +76,7 @@
   },
   "devDependencies": {
     "@podman-desktop/quadlet-extension-core-api": "workspace:^",
-    "@podman-desktop/api": "^1.26.2",
+    "@podman-desktop/api": "^1.28.2",
     "@podman-desktop/podman-extension-api": "^1.26.1",
     "@types/node": "^24",
     "@types/ssh2": "^1.15.5",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -77,7 +77,7 @@
   "devDependencies": {
     "@podman-desktop/quadlet-extension-core-api": "workspace:^",
     "@podman-desktop/api": "^1.28.2",
-    "@podman-desktop/podman-extension-api": "^1.26.1",
+    "@podman-desktop/podman-extension-api": "^1.28.2",
     "@types/node": "^24",
     "@types/ssh2": "^1.15.5",
     "@types/ssh2-sftp-client": "^9.0.6",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -27,7 +27,7 @@
     "@fortawesome/free-brands-svg-icons": "^7.3.1",
     "@fortawesome/free-regular-svg-icons": "^7.3.1",
     "@fortawesome/free-solid-svg-icons": "^7.3.1",
-    "@podman-desktop/ui-svelte": "^1.26.1",
+    "@podman-desktop/ui-svelte": "^1.28.2",
     "@sveltejs/vite-plugin-svelte": "7.2.0",
     "@tailwindcss/typography": "^0.5.20",
     "@tailwindcss/vite": "^4.3.3",

--- a/packages/frontend/src/lib/buttons/RadioButtons.spec.ts
+++ b/packages/frontend/src/lib/buttons/RadioButtons.spec.ts
@@ -70,7 +70,8 @@ test('disable radio buttons should have proper styling', async () => {
   const buttons = getAllByRole('radio');
   expect(buttons).toHaveLength(OPTIONS.length);
   for (const button of buttons) {
-    expect(button).toHaveClass('bg-[var(--pd-button-disabled)]');
-    expect(button).toHaveClass('text-[var(--pd-button-disabled-text)]');
+    expect(button).toHaveClass('bg-(--pd-button-disabled)');
+    expect(button).toHaveClass('text-(--pd-button-disabled-text)');
+    expect(button).toHaveClass('cursor-not-allowed');
   }
 });

--- a/packages/frontend/src/lib/buttons/RadioButtons.svelte
+++ b/packages/frontend/src/lib/buttons/RadioButtons.svelte
@@ -33,15 +33,12 @@ function onclick(id: string): void {
         role="radio"
         aria-checked={selected}
         onclick={onclick.bind(undefined, option.id)}
-        class:bg-[var(--pd-button-primary-bg)]={selected && !disabled}
-        class:bg-[var(--pd-button-disabled)]={disabled}
-        class:text-[var(--pd-button-text)]={selected && !disabled}
-        class:text-[var(--pd-button-disabled-text)]={disabled}
-        class:text-[var(--pd-button-secondary)]={!disabled}
-        class:hover:text-[var(--pd-button-text)]={!disabled}
-        class:hover:bg-[var(--pd-button-secondary-hover)]={!disabled}
-        class:cursor-not-allowed={disabled}
-        class="inline-block w-full h-full"
+        class={['inline-block w-full h-full', {
+          'bg-(--pd-button-primary-bg) text-(--pd-button-primary-text)': selected && !disabled,
+          'text-[var(--pd-button-secondary-text)] hover:bg-[var(--pd-button-secondary-hover-bg)]': !selected && !disabled,
+          'bg-(--pd-button-disabled) text-(--pd-button-disabled-text) cursor-not-allowed': disabled,
+          'cursor-pointer': !disabled,
+        }]}
         title={option.label}
         aria-label={option.label}
         aria-current="page">

--- a/packages/frontend/src/lib/buttons/RadioButtons.svelte
+++ b/packages/frontend/src/lib/buttons/RadioButtons.svelte
@@ -33,12 +33,16 @@ function onclick(id: string): void {
         role="radio"
         aria-checked={selected}
         onclick={onclick.bind(undefined, option.id)}
-        class={['inline-block w-full h-full', {
-          'bg-(--pd-button-primary-bg) text-(--pd-button-primary-text)': selected && !disabled,
-          'text-[var(--pd-button-secondary-text)] hover:bg-[var(--pd-button-secondary-hover-bg)]': !selected && !disabled,
-          'bg-(--pd-button-disabled) text-(--pd-button-disabled-text) cursor-not-allowed': disabled,
-          'cursor-pointer': !disabled,
-        }]}
+        class={[
+          'inline-block w-full h-full',
+          {
+            'bg-(--pd-button-primary-bg) text-(--pd-button-primary-text)': selected && !disabled,
+            'text-[var(--pd-button-secondary-text)] hover:bg-[var(--pd-button-secondary-hover-bg)]':
+              !selected && !disabled,
+            'bg-(--pd-button-disabled) text-(--pd-button-disabled-text) cursor-not-allowed': disabled,
+            'cursor-pointer': !disabled,
+          },
+        ]}
         title={option.label}
         aria-label={option.label}
         aria-current="page">

--- a/packages/frontend/tailwind.config.cjs
+++ b/packages/frontend/tailwind.config.cjs
@@ -21,42 +21,7 @@ module.exports = {
       '5xl': '30px',
       '6xl': '36px',
     },
-    colors: {
-      'charcoal': {
-        600: '#27272a',
-        800: '#18181b',
-      },
-      'gray': {
-        400: '#d1d1d1',
-        700: '#aaabac',
-        900: '#818181',
-      },
-      'purple': {
-        400: '#ad8bfa',
-        500: '#8b5cf6',
-      },
-      'sky': {
-        400: '#51a2da',
-      },
-      'green': {
-        600: '#2b7037',
-      },
-      'red': {
-        600: '#e5421d',
-      },
-      'amber': {
-        600: tailwindColors.amber[600],
-      },
-      transparent: 'transparent',
-      black: '#000',
-      white: '#fff',
-      // The remaining colors below are not part of our palette and are only here
-      // to maintain existing code. No new use.
-      'violet': {
-        500: tailwindColors.violet[500],
-        600: tailwindColors.violet[600],
-      },
-    },
+    colors: {},
   },
   plugins: [
     tailwindTypography

--- a/packages/podlet-js/package.json
+++ b/packages/podlet-js/package.json
@@ -19,7 +19,7 @@
     "@codecov/vite-plugin": "^2.0.1",
     "vite-plugin-dts": "^5.0.3",
     "@types/js-yaml": "^4.0.9",
-    "@podman-desktop/api": "^1.26.2"
+    "@podman-desktop/api": "^1.28.2"
   },
   "dependencies": {
     "js-ini": "^1.6.0",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -17,7 +17,7 @@
     "vite": "^8.1.5",
     "vite-plugin-dts": "^5.0.3",
     "vitest": "^4.1.10",
-    "@podman-desktop/api": "^1.26.2"
+    "@podman-desktop/api": "^1.28.2"
   },
   "files": [
     "dist",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,8 +146,8 @@ importers:
         specifier: ^1.28.2
         version: 1.28.2
       '@podman-desktop/podman-extension-api':
-        specifier: ^1.26.1
-        version: 1.26.1
+        specifier: ^1.28.2
+        version: 1.28.3
       '@podman-desktop/quadlet-extension-core-api':
         specifier: workspace:^
         version: link:../shared
@@ -213,8 +213,8 @@ importers:
         specifier: ^7.3.1
         version: 7.3.1
       '@podman-desktop/ui-svelte':
-        specifier: ^1.26.1
-        version: 1.26.1(svelte-fa@4.0.4(svelte@5.56.7(@typescript-eslint/types@8.65.0)))(svelte@5.56.7(@typescript-eslint/types@8.65.0))
+        specifier: ^1.28.2
+        version: 1.28.3(svelte-fa@4.0.4(svelte@5.56.7(@typescript-eslint/types@8.65.0)))(svelte@5.56.7(@typescript-eslint/types@8.65.0))
       '@sveltejs/vite-plugin-svelte':
         specifier: 7.2.0
         version: 7.2.0(svelte@5.56.7(@typescript-eslint/types@8.65.0))(vite@8.1.5(@types/node@24.10.9)(jiti@2.7.0))
@@ -909,20 +909,20 @@ packages:
     resolution: {integrity: sha512-//0sR/cow/s4ICQaYoAobOl4aU8cjU6x/V24V7XkKotb9+O+3zySIYp146vpaobYHnxa4pZX8NkV54Z5AwbDKA==}
     engines: {node: '>=12'}
 
-  '@podman-desktop/api@1.26.1':
-    resolution: {integrity: sha512-mp6+UgOY/lzAy6ieeyWL9xPEdYiYEig5a5vLbmDFZu7/y/uihvxUQQ75VGZQeq37I2xpDztll95fY/NdypoZ1w==}
-
   '@podman-desktop/api@1.28.2':
     resolution: {integrity: sha512-kSBVWUSyuijS5a9HvqFAlihmy6D26nwTPZ0Yw9K/2W11grWeI/AvaS+THTmxHvXk8EbB9y8ydWpXhA8el67NKQ==}
 
-  '@podman-desktop/podman-extension-api@1.26.1':
-    resolution: {integrity: sha512-OUj+f3WVHdU602hn2OKXEbSTSM4VLR4rL1a4qBAWf2H8I/KrKJmPPDopKd0/pUeeSyUfElyfwAERrHHYDVjU7w==}
+  '@podman-desktop/api@1.28.3':
+    resolution: {integrity: sha512-RCYrD90VfVn59oa8vTaDXj8Qy9BD0jxyiTNBhKNcloYf1hBCDMIKgqTcXYgNq15/5P1aGjRmgaG/jnhDEuux/g==}
+
+  '@podman-desktop/podman-extension-api@1.28.3':
+    resolution: {integrity: sha512-j9OwVI3uN9nxLDtSwKwak8Xgw7TWRV0nlxm/Kop1OFv+EJF7Nb+0wXL8A6z011hA86XKWg7wFAF3HXS5hflZqw==}
 
   '@podman-desktop/tests-playwright@1.28.2':
     resolution: {integrity: sha512-7LXWwf3QkPL6GNNzJGZ4rfeUtXuYbb8+WPhzfPrYP/ndt3NIKl+onW1m9VqriHZpZ/U4me+8pjsrAUZstDPD7g==}
 
-  '@podman-desktop/ui-svelte@1.26.1':
-    resolution: {integrity: sha512-8oYg+5mc0ReMeeCSfXX2TmqOqln+A69UoRPw3XQ8qmtWOkV+cnATRfNGztE9Dqs9OS9srngoCZ210t6U5IhdjA==}
+  '@podman-desktop/ui-svelte@1.28.3':
+    resolution: {integrity: sha512-kodRltBjRKVkd40YNZRnU50TDGEmG/rW9YgnDk5S+w35WPglea8LOMP4fUZKRsXmFhj4OTqIyNgVHyXo01d0jQ==}
     peerDependencies:
       svelte: ^4.0.0 || ^5.0.0
       svelte-fa: ^4.0.0
@@ -4767,17 +4767,17 @@ snapshots:
       '@pnpm/network.ca-file': 1.0.2
       config-chain: 1.1.13
 
-  '@podman-desktop/api@1.26.1': {}
-
   '@podman-desktop/api@1.28.2': {}
 
-  '@podman-desktop/podman-extension-api@1.26.1':
+  '@podman-desktop/api@1.28.3': {}
+
+  '@podman-desktop/podman-extension-api@1.28.3':
     dependencies:
-      '@podman-desktop/api': 1.26.1
+      '@podman-desktop/api': 1.28.3
 
   '@podman-desktop/tests-playwright@1.28.2': {}
 
-  '@podman-desktop/ui-svelte@1.26.1(svelte-fa@4.0.4(svelte@5.56.7(@typescript-eslint/types@8.65.0)))(svelte@5.56.7(@typescript-eslint/types@8.65.0))':
+  '@podman-desktop/ui-svelte@1.28.3(svelte-fa@4.0.4(svelte@5.56.7(@typescript-eslint/types@8.65.0)))(svelte@5.56.7(@typescript-eslint/types@8.65.0))':
     dependencies:
       '@floating-ui/dom': 1.7.6
       '@fortawesome/fontawesome-free': 7.3.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -143,8 +143,8 @@ importers:
         specifier: ^2.0.1
         version: 2.0.1(vite@8.1.5(@types/node@24.10.9)(jiti@2.7.0))
       '@podman-desktop/api':
-        specifier: ^1.26.2
-        version: 1.26.2
+        specifier: ^1.28.2
+        version: 1.28.2
       '@podman-desktop/podman-extension-api':
         specifier: ^1.26.1
         version: 1.26.1
@@ -307,8 +307,8 @@ importers:
         specifier: ^2.0.1
         version: 2.0.1(vite@8.1.5(@types/node@24.10.9)(jiti@2.7.0))
       '@podman-desktop/api':
-        specifier: ^1.26.2
-        version: 1.26.2
+        specifier: ^1.28.2
+        version: 1.28.2
       '@types/js-yaml':
         specifier: ^4.0.9
         version: 4.0.9
@@ -328,8 +328,8 @@ importers:
   packages/shared:
     devDependencies:
       '@podman-desktop/api':
-        specifier: ^1.26.2
-        version: 1.26.2
+        specifier: ^1.28.2
+        version: 1.28.2
       vite:
         specifier: ^8.1.5
         version: 8.1.5(@types/node@24.10.9)(jiti@2.7.0)
@@ -912,8 +912,8 @@ packages:
   '@podman-desktop/api@1.26.1':
     resolution: {integrity: sha512-mp6+UgOY/lzAy6ieeyWL9xPEdYiYEig5a5vLbmDFZu7/y/uihvxUQQ75VGZQeq37I2xpDztll95fY/NdypoZ1w==}
 
-  '@podman-desktop/api@1.26.2':
-    resolution: {integrity: sha512-LE8uo8PsyUG7gfrg0IW/Eib6SeZn717usJSwiuzpDMTSZJCTwlaXDeEADxMXLfsu6V9OKjZtgwJ7SAVzaeTV7A==}
+  '@podman-desktop/api@1.28.2':
+    resolution: {integrity: sha512-kSBVWUSyuijS5a9HvqFAlihmy6D26nwTPZ0Yw9K/2W11grWeI/AvaS+THTmxHvXk8EbB9y8ydWpXhA8el67NKQ==}
 
   '@podman-desktop/podman-extension-api@1.26.1':
     resolution: {integrity: sha512-OUj+f3WVHdU602hn2OKXEbSTSM4VLR4rL1a4qBAWf2H8I/KrKJmPPDopKd0/pUeeSyUfElyfwAERrHHYDVjU7w==}
@@ -4769,7 +4769,7 @@ snapshots:
 
   '@podman-desktop/api@1.26.1': {}
 
-  '@podman-desktop/api@1.26.2': {}
+  '@podman-desktop/api@1.28.2': {}
 
   '@podman-desktop/podman-extension-api@1.26.1':
     dependencies:


### PR DESCRIPTION
## Description

Updating manually the `@podman-desktop/*` group. 

- Cleanup the tailwindcss colors
- Update `packages/frontend/src/lib/buttons/RadioButtons.svelte` to use appropriate colors

## Screenshots

**Before**

<img width="992" height="774" alt="image" src="https://github.com/user-attachments/assets/3b607431-9da4-4310-a52d-ef72309299f5" />

**After**

<img width="992" height="774" alt="image" src="https://github.com/user-attachments/assets/364faf62-185e-4c36-8d8a-9f3671dbe743" />

## Related issues

Fixes https://github.com/podman-desktop/extension-podman-quadlet/issues/1512

Supersede https://github.com/podman-desktop/extension-podman-quadlet/pull/1583