### PR TITLE
fix: discover and manage rootful (system-wide) quadlets

### DIFF
--- a/packages/backend/src/apis/quadlet-api-impl.spec.ts
+++ b/packages/backend/src/apis/quadlet-api-impl.spec.ts
@@ -197,6 +197,23 @@ describe.each(['start', 'stop', 'restart'] as Array<'start' | 'stop' | 'restart'
       admin: false,
     });
   });
+
+  test('should call systemd#[func] with admin:true for a rootful (system-wide) quadlet', async () => {
+    vi.mocked(QUADLET_SERVICE.getQuadlet).mockReturnValue({
+      ...QUADLET_MOCK,
+      admin: true,
+    });
+
+    const api = getQuadletApiImpl();
+
+    await api[func](WSL_PROVIDER_IDENTIFIER, QUADLET_MOCK.id);
+
+    expect(SYSTEMD_SERVICE[func]).toHaveBeenCalledWith({
+      provider: WSL_PROVIDER_CONNECTION_MOCK,
+      service: QUADLET_MOCK.service,
+      admin: true,
+    });
+  });
 });
 
 describe('QuadletApiImpl#createQuadletLogger', () => {
@@ -245,6 +262,29 @@ describe('QuadletApiImpl#createQuadletLogger', () => {
 
     expect(PODMAN_WORKER_MOCK.journalctlExec).toHaveBeenCalledWith({
       args: ['--user', '--follow', `--unit=${QUADLET_MOCK.service}`, '--output=cat'],
+      logger: LOGGER_MOCK,
+      token: expect.anything(),
+      env: {
+        SYSTEMD_COLORS: 'true',
+      },
+    });
+  });
+
+  test('should not pass --user for a rootful (system-wide) quadlet', async () => {
+    vi.mocked(QUADLET_SERVICE.getQuadlet).mockReturnValue({
+      ...QUADLET_MOCK,
+      admin: true,
+    });
+
+    const api = getQuadletApiImpl();
+
+    await api.createQuadletLogger({
+      connection: WSL_PROVIDER_IDENTIFIER,
+      quadletId: QUADLET_MOCK.id,
+    });
+
+    expect(PODMAN_WORKER_MOCK.journalctlExec).toHaveBeenCalledWith({
+      args: ['--follow', `--unit=${QUADLET_MOCK.service}`, '--output=cat'],
       logger: LOGGER_MOCK,
       token: expect.anything(),
       env: {

--- a/packages/backend/src/apis/quadlet-api-impl.ts
+++ b/packages/backend/src/apis/quadlet-api-impl.ts
@@ -148,7 +148,6 @@ export class QuadletApiImpl extends QuadletApi {
     return await this.dependencies.quadlet.read({
       provider: providerConnection,
       id: id,
-      admin: false,
     });
   }
 

--- a/packages/backend/src/apis/quadlet-api-impl.ts
+++ b/packages/backend/src/apis/quadlet-api-impl.ts
@@ -68,7 +68,7 @@ export class QuadletApiImpl extends QuadletApi {
       return await this.dependencies.systemd.start({
         service: quadlet.service,
         provider: providerConnection,
-        admin: false,
+        admin: quadlet.admin ?? false,
       });
     } finally {
       this.dependencies.quadlet.refreshQuadletsStatuses().catch(console.error);
@@ -95,7 +95,7 @@ export class QuadletApiImpl extends QuadletApi {
       return await this.dependencies.systemd.stop({
         service: quadlet.service,
         provider: providerConnection,
-        admin: false,
+        admin: quadlet.admin ?? false,
       });
     } finally {
       this.dependencies.quadlet.refreshQuadletsStatuses().catch(console.error);
@@ -122,7 +122,7 @@ export class QuadletApiImpl extends QuadletApi {
       return await this.dependencies.systemd.restart({
         service: quadlet.service,
         provider: providerConnection,
-        admin: false,
+        admin: quadlet.admin ?? false,
       });
     } finally {
       this.dependencies.quadlet.refreshQuadletsStatuses().catch(console.error);
@@ -136,7 +136,6 @@ export class QuadletApiImpl extends QuadletApi {
       return await this.dependencies.quadlet.remove({
         provider: providerConnection,
         ids: ids,
-        admin: false,
       });
     } finally {
       this.dependencies.quadlet.refreshQuadletsStatuses().catch(console.error);
@@ -177,10 +176,12 @@ export class QuadletApiImpl extends QuadletApi {
     // get the worker
     const worker: PodmanWorker = await this.dependencies.podman.getWorker(providerConnection);
 
+    const journalctlArgs = quadlet.admin ? [] : ['--user'];
+
     // do not wait for the returned value as we --follow
     worker
       .journalctlExec({
-        args: ['--user', '--follow', `--unit=${quadlet.service}`, '--output=cat'],
+        args: [...journalctlArgs, '--follow', `--unit=${quadlet.service}`, '--output=cat'],
         env: {
           SYSTEMD_COLORS: 'true',
         },

--- a/packages/backend/src/services/podman-service.spec.ts
+++ b/packages/backend/src/services/podman-service.spec.ts
@@ -66,6 +66,15 @@ const WSL_CONNECTION_INFO_MOCK: PodmanConnection = {
   ReadWrite: true,
 };
 
+const WSL_ROOTFUL_CONNECTION_INFO_MOCK: PodmanConnection = {
+  Name: `${WSL_PROVIDER_CONNECTION_MOCK.connection.name}-root`,
+  IsMachine: true,
+  URI: 'ssh://root@127.0.0.1:34427/run/podman/podman.sock',
+  Identity: '/home/potatoes/machine.socket',
+  Default: false,
+  ReadWrite: true,
+};
+
 const NATIVE_PROVIDER_CONNECTION_MOCK: ProviderContainerConnection = {
   connection: {
     type: 'podman',
@@ -134,7 +143,7 @@ describe('PodmanService#init', () => {
     const connections = await podman.getPodmanConnections();
     expect(connections).toHaveLength(1);
 
-    expect(podman.getConnection(WSL_PROVIDER_CONNECTION_MOCK)).toStrictEqual(WSL_CONNECTION_INFO_MOCK);
+    expect(connections[0]).toStrictEqual(WSL_CONNECTION_INFO_MOCK);
   });
 });
 
@@ -142,7 +151,7 @@ describe('PodmanService#getWorker', () => {
   let podman: PodmanService;
   beforeEach(async () => {
     vi.mocked(podmanExtensionApiMock.exports.exec).mockResolvedValue({
-      stdout: JSON.stringify([WSL_CONNECTION_INFO_MOCK]),
+      stdout: JSON.stringify([WSL_CONNECTION_INFO_MOCK, WSL_ROOTFUL_CONNECTION_INFO_MOCK]),
       stderr: '',
       command: 'dummy-command',
     });
@@ -198,6 +207,29 @@ describe('PodmanService#getWorker', () => {
     // only created once
     expect(PodmanNativeWorker).toHaveBeenCalledOnce();
     expect(PodmanSSHWorker).not.toHaveBeenCalled();
+  });
+
+  test('rootful remote connection should be created', async () => {
+    podman = getPodmanService({
+      isWindows: true,
+    });
+    await podman.init();
+
+    // mock machine rootful
+    vi.spyOn(podman, 'isMachineRootful').mockResolvedValue(true);
+
+    const worker = await podman.getWorker(WSL_PROVIDER_CONNECTION_MOCK);
+    expect(worker).toBeDefined();
+
+    expect(PodmanSSHWorker).toHaveBeenCalledOnce();
+    expect(PodmanNativeWorker).not.toHaveBeenCalled();
+
+    expect(PodmanSSHWorker).toHaveBeenCalledExactlyOnceWith(
+      WSL_PROVIDER_CONNECTION_MOCK,
+      expect.objectContaining({
+        username: 'root',
+      }),
+    );
   });
 });
 

--- a/packages/backend/src/services/podman-service.ts
+++ b/packages/backend/src/services/podman-service.ts
@@ -72,13 +72,37 @@ export class PodmanService extends PodmanHelper implements Disposable, AsyncInit
     this.#connections = new Map<string, PodmanConnection>(connections.map(connection => [connection.Name, connection]));
   }
 
-  public hasConnection(connection: ProviderContainerConnection): boolean {
-    return this.#connections?.has(connection.connection.name) ?? false;
+  /**
+   * Podman Desktop provides a list of {@link ProviderContainerConnection} however,
+   * it does not provide a way to know if a connection is rootful or not.
+   *
+   * To get the corresponding `podman system connection ls` if rootful, we need to add the `-root` suffix
+   *
+   * @param connection
+   * @param rootful
+   * @protected
+   */
+  protected getConnectionName(connection: ProviderContainerConnection, rootful: boolean): string {
+    if (rootful) {
+      // only connection on machine can have a rootful version
+      if (!connection.connection.vmType) {
+        throw new Error('connection provided is not a podman machine');
+      }
+      return `${connection.connection.name}-root`;
+    }
+
+    return connection.connection.name;
   }
 
-  public getConnection(connection: ProviderContainerConnection): PodmanConnection {
-    const remote = this.#connections?.get(connection.connection.name);
-    if (!remote) throw new Error(`could not get remote connection for connection ${connection.connection.name}`);
+  protected hasConnection(connection: ProviderContainerConnection, rootful: boolean): boolean {
+    return this.#connections?.has(this.getConnectionName(connection, rootful)) ?? false;
+  }
+
+  protected getConnection(connection: ProviderContainerConnection, rootful: boolean): PodmanConnection {
+    const name = this.getConnectionName(connection, rootful);
+
+    const remote = this.#connections?.get(name);
+    if (!remote) throw new Error(`could not get remote connection for connection ${name}`);
     return remote;
   }
 
@@ -99,8 +123,12 @@ export class PodmanService extends PodmanHelper implements Disposable, AsyncInit
     const worker = this.#pools.get(key);
     if (worker) return worker;
 
-    // detect podman linux native
-    if (this.isLinux && !this.hasConnection(connection)) {
+    /**
+     * Detect podman linux native
+     * - it does not have a vmType
+     * - it does not have a connection with the same name
+     */
+    if (this.isLinux && !connection.connection.vmType && !this.hasConnection(connection, false)) {
       const native = new PodmanNativeWorker(connection, this.dependencies.processApi);
       // init
       await native.init();
@@ -109,8 +137,18 @@ export class PodmanService extends PodmanHelper implements Disposable, AsyncInit
       return native;
     }
 
+    /**
+     * A machine can be either rootful or rootless.
+     */
+    let rootfull: boolean;
+    if (connection.connection.vmType) {
+      rootfull = await this.isMachineRootful(connection);
+    } else {
+      rootfull = false;
+    }
+
     // create PodmanSSHWorker
-    const { URI, Identity, IsMachine } = this.getConnection(connection);
+    const { URI, Identity, IsMachine } = this.getConnection(connection, rootfull);
     if (!IsMachine) {
       console.warn('[PodmanWorkers] detected remote connection: this is an experimental feature');
     }

--- a/packages/backend/src/services/quadlet-service.spec.ts
+++ b/packages/backend/src/services/quadlet-service.spec.ts
@@ -77,6 +77,7 @@ const PODMAN_WORKER_MOCK: PodmanWorker = {
   exec: vi.fn(),
   systemctlExec: vi.fn(),
   quadletExec: vi.fn(),
+  isRootless: vi.fn(),
 } as unknown as PodmanWorker;
 
 const SYSTEMD_SERVICE_MOCK: SystemdService = {
@@ -185,6 +186,8 @@ beforeEach(() => {
   vi.mocked(SPECIFIERS_MOCK.expand).mockImplementation(async (_, path) => path);
 
   vi.mocked(PODMAN_SERVICE_MOCK.getWorker).mockResolvedValue(PODMAN_WORKER_MOCK);
+  // default: rootless connection, matching the extension's pre-existing (--user only) behaviour
+  vi.mocked(PODMAN_WORKER_MOCK.isRootless).mockResolvedValue(true);
   vi.mocked(PODMAN_WORKER_MOCK.quadletExec).mockResolvedValue(RUN_RESULT_MOCK);
   vi.mocked(QuadletDryRunParser.prototype.parse).mockResolvedValue([
     QUADLET_MOCK,
@@ -298,18 +301,36 @@ describe('QuadletService#collectPodmanQuadlet', () => {
     });
   });
 
-  test('should use PodmanService#quadletExec to get quadlet dry-run', async () => {
+  test('should use PodmanService#quadletExec with -user for a rootless connection', async () => {
+    vi.mocked(PODMAN_WORKER_MOCK.isRootless).mockResolvedValue(true);
+
     const quadlet = getQuadletService();
     await quadlet.collectPodmanQuadlet();
 
     expect(PODMAN_SERVICE_MOCK.getWorker).toHaveBeenCalledWith(WSL_RUNNING_PROVIDER_CONNECTION_MOCK);
 
-    expect(PODMAN_WORKER_MOCK.quadletExec).toHaveBeenCalledWith({
+    expect(PODMAN_WORKER_MOCK.quadletExec).toHaveBeenCalledExactlyOnceWith({
       args: ['-dryrun', '-user'],
       token: CANCELLATION_TOKEN,
     });
 
     expect(quadlet.all()).toHaveLength(5);
+    expect(quadlet.all().every(q => q.admin === false)).toBe(true);
+  });
+
+  test('should use PodmanService#quadletExec without -user for a rootful connection', async () => {
+    vi.mocked(PODMAN_WORKER_MOCK.isRootless).mockResolvedValue(false);
+
+    const quadlet = getQuadletService();
+    await quadlet.collectPodmanQuadlet();
+
+    expect(PODMAN_WORKER_MOCK.quadletExec).toHaveBeenCalledExactlyOnceWith({
+      args: ['-dryrun'],
+      token: CANCELLATION_TOKEN,
+    });
+
+    expect(quadlet.all()).toHaveLength(5);
+    expect(quadlet.all().every(q => q.admin === true)).toBe(true);
   });
 });
 

--- a/packages/backend/src/services/quadlet-service.ts
+++ b/packages/backend/src/services/quadlet-service.ts
@@ -299,10 +299,6 @@ export class QuadletService extends QuadletHelper implements Disposable, AsyncIn
    */
   async writeIntoMachine(options: {
     provider: ProviderContainerConnection;
-    /**
-     * @default false (Run as systemd user)
-     */
-    admin?: boolean;
     files: Array<{ filename: string; content: string }>;
     /**
      * When writing to the machine, by default the code will call systemd daemon-reload
@@ -310,9 +306,7 @@ export class QuadletService extends QuadletHelper implements Disposable, AsyncIn
      */
     skipSystemdDaemonReload?: boolean;
   }): Promise<void> {
-    const telemetry: Record<string, unknown> = {
-      admin: options.admin,
-    };
+    const telemetry: Record<string, unknown> = {};
 
     // note the number of files we update
     telemetry['files-length'] = options.files.length;
@@ -327,6 +321,7 @@ export class QuadletService extends QuadletHelper implements Disposable, AsyncIn
         async () => {
           // Get the worker
           const worker: PodmanWorker = await this.podman.getWorker(options.provider);
+          const rootless = await worker.isRootless();
 
           // write all files sequentially - do not try to run them in parallel
           for (const { filename, content } of options.files) {
@@ -334,7 +329,7 @@ export class QuadletService extends QuadletHelper implements Disposable, AsyncIn
             if (!isRelative(filename)) {
               destination = filename;
             } else {
-              if (options.admin) {
+              if (!rootless) {
                 destination = joinposix('/etc/containers/systemd', filename);
               } else {
                 destination = joinposix('~/.config/containers/systemd', filename);
@@ -360,7 +355,7 @@ export class QuadletService extends QuadletHelper implements Disposable, AsyncIn
           if (!options.skipSystemdDaemonReload) {
             // reload
             await this.dependencies.systemd.daemonReload({
-              admin: options.admin ?? false,
+              admin: !rootless,
               provider: options.provider,
             });
 
@@ -461,14 +456,7 @@ export class QuadletService extends QuadletHelper implements Disposable, AsyncIn
    * read the source of the given quadlet
    * @param options
    */
-  async read(options: {
-    id: string;
-    provider: ProviderContainerConnection;
-    /**
-     * @default false (Run as systemd user)
-     */
-    admin?: boolean;
-  }): Promise<string> {
+  async read(options: { id: string; provider: ProviderContainerConnection }): Promise<string> {
     const quadlet = this.findQuadlet({
       provider: options.provider,
       id: options.id,

--- a/packages/backend/src/services/quadlet-service.ts
+++ b/packages/backend/src/services/quadlet-service.ts
@@ -165,7 +165,11 @@ export class QuadletService extends QuadletHelper implements Disposable, AsyncIn
     }
 
     const parser = new QuadletDryRunParser(result);
-    return parser.parse();
+    // tag each quadlet with the scope it was collected from, so later operations
+    // (start/stop/status/remove) know whether to use `--user` or not.
+    return Promise.resolve(parser.parse()).then(quadlets =>
+      quadlets.map(quadlet => ({ ...quadlet, admin: options.admin ?? false })),
+    );
   }
 
   async collectPodmanQuadlet(): Promise<void> {
@@ -198,8 +202,12 @@ export class QuadletService extends QuadletHelper implements Disposable, AsyncIn
               message: `Collecting quadlets ${provider.connection.name}`,
             });
 
-            // 1. get the quadlets
-            const quadlets = await this.getPodmanQuadlets({ provider, token, admin: false });
+            // 1. determine whether this connection's engine is rootless or rootful, and only
+            // collect quadlets from the matching scope (mirrors how the Containers page never
+            // mixes rootful/rootless content for a single connection)
+            const worker: PodmanWorker = await this.podman.getWorker(provider);
+            const rootless = await worker.isRootless({ token });
+            const quadlets = await this.getPodmanQuadlets({ provider, token, admin: !rootless });
 
             // 2. update internally but do not notify (we need to collect the statuses)
             this.update(provider, quadlets, false);
@@ -252,10 +260,14 @@ export class QuadletService extends QuadletHelper implements Disposable, AsyncIn
         // filter service quadlet and filter out template quadlet
         .filter((quadlet): quadlet is ServiceQuadlet => isServiceQuadlet(quadlet) && !isTemplateQuadlet(quadlet));
 
-      // get the statuses of the quadlets with a corresponding service
+      // a connection only ever collects quadlets from a single scope (see collectPodmanQuadlet),
+      // so a single status check in that same scope covers every quadlet here
+      const worker: PodmanWorker = await this.podman.getWorker(provider);
+      const rootless = await worker.isRootless();
+
       const statuses = await this.dependencies.systemd.getActiveStatus({
         provider: provider,
-        admin: false,
+        admin: !rootless,
         services: serviceQuadlets.map(quadlet => quadlet.service),
       });
 
@@ -366,19 +378,10 @@ export class QuadletService extends QuadletHelper implements Disposable, AsyncIn
       });
   }
 
-  async remove(options: {
-    ids: string[];
-    provider: ProviderContainerConnection;
-    /**
-     * @default false (Run as systemd user)
-     */
-    admin?: boolean;
-  }): Promise<void> {
+  async remove(options: { ids: string[]; provider: ProviderContainerConnection }): Promise<void> {
     if (options.ids.length === 0) throw new Error('cannot delete zero quadlets.');
 
-    const telemetry: Record<string, unknown> = {
-      admin: options.admin,
-    };
+    const telemetry: Record<string, unknown> = {};
 
     // title depends on the number of quadlets
     const title: string =
@@ -432,10 +435,11 @@ export class QuadletService extends QuadletHelper implements Disposable, AsyncIn
             progress.report({ message: `Removed quadlet ${quadlets[0].id}.` });
           }
 
-          // 3. reload systemctl
+          // 3. reload systemctl, in this connection's scope
           console.debug(`[QuadletService] Reloading systemctl`);
+          const rootless = await worker.isRootless();
           await this.dependencies.systemd.daemonReload({
-            admin: options.admin ?? false,
+            admin: !rootless,
             provider: options.provider,
           });
         },

--- a/packages/backend/src/utils/resolvers/rootless-resolver.spec.ts
+++ b/packages/backend/src/utils/resolvers/rootless-resolver.spec.ts
@@ -1,0 +1,77 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { expect, test, vi, beforeEach } from 'vitest';
+import { RootlessResolver, ROOTLESS_FALLBACK } from '/@/utils/resolvers/rootless-resolver';
+import type { PodmanWorker } from '/@/utils/worker/podman-worker';
+
+const PODMAN_WORKER_MOCK: PodmanWorker = {
+  podmanExec: vi.fn(),
+} as unknown as PodmanWorker;
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+test('should return false for a rootful connection', async () => {
+  const resolver = new RootlessResolver(PODMAN_WORKER_MOCK);
+  vi.mocked(PODMAN_WORKER_MOCK.podmanExec).mockResolvedValue({
+    stdout: 'false\n',
+    stderr: '',
+    command: 'podman info --format {{.Host.Security.Rootless}}',
+  });
+
+  await expect(resolver.resolve()).resolves.toBe(false);
+
+  expect(PODMAN_WORKER_MOCK.podmanExec).toHaveBeenCalledWith({
+    args: ['info', '--format', '{{.Host.Security.Rootless}}'],
+  });
+});
+
+test('should return true for a rootless connection', async () => {
+  const resolver = new RootlessResolver(PODMAN_WORKER_MOCK);
+  vi.mocked(PODMAN_WORKER_MOCK.podmanExec).mockResolvedValue({
+    stdout: 'true\n',
+    stderr: '',
+    command: 'podman info --format {{.Host.Security.Rootless}}',
+  });
+
+  await expect(resolver.resolve()).resolves.toBe(true);
+});
+
+test('should cache the result on success', async () => {
+  const resolver = new RootlessResolver(PODMAN_WORKER_MOCK);
+  vi.mocked(PODMAN_WORKER_MOCK.podmanExec).mockResolvedValue({
+    stdout: 'false\n',
+    stderr: '',
+    command: 'podman info --format {{.Host.Security.Rootless}}',
+  });
+
+  for (let i = 0; i < 10; i++) {
+    await expect(resolver.resolve()).resolves.toBe(false);
+  }
+
+  expect(PODMAN_WORKER_MOCK.podmanExec).toHaveBeenCalledOnce();
+});
+
+test('error in podmanExec should fallback to ROOTLESS_FALLBACK', async () => {
+  const resolver = new RootlessResolver(PODMAN_WORKER_MOCK);
+  vi.mocked(PODMAN_WORKER_MOCK.podmanExec).mockRejectedValue(new Error('Something went wrong'));
+
+  await expect(resolver.resolve()).resolves.toBe(ROOTLESS_FALLBACK);
+});

--- a/packages/backend/src/utils/resolvers/rootless-resolver.spec.ts
+++ b/packages/backend/src/utils/resolvers/rootless-resolver.spec.ts
@@ -19,6 +19,7 @@
 import { expect, test, vi, beforeEach } from 'vitest';
 import { RootlessResolver, ROOTLESS_FALLBACK } from '/@/utils/resolvers/rootless-resolver';
 import type { PodmanWorker } from '/@/utils/worker/podman-worker';
+import type { CancellationToken } from '@podman-desktop/api';
 
 const PODMAN_WORKER_MOCK: PodmanWorker = {
   podmanExec: vi.fn(),
@@ -74,4 +75,42 @@ test('error in podmanExec should fallback to ROOTLESS_FALLBACK', async () => {
   vi.mocked(PODMAN_WORKER_MOCK.podmanExec).mockRejectedValue(new Error('Something went wrong'));
 
   await expect(resolver.resolve()).resolves.toBe(ROOTLESS_FALLBACK);
+});
+
+test('malformed stdout should fallback to ROOTLESS_FALLBACK rather than resolving to rootful', async () => {
+  const resolver = new RootlessResolver(PODMAN_WORKER_MOCK);
+  vi.mocked(PODMAN_WORKER_MOCK.podmanExec).mockResolvedValue({
+    stdout: '',
+    stderr: 'some unexpected error output',
+    command: 'podman info --format {{.Host.Security.Rootless}}',
+  });
+
+  await expect(resolver.resolve()).resolves.toBe(ROOTLESS_FALLBACK);
+});
+
+test('should cache the fallback after a non-cancellation failure', async () => {
+  const resolver = new RootlessResolver(PODMAN_WORKER_MOCK);
+  vi.mocked(PODMAN_WORKER_MOCK.podmanExec).mockRejectedValue(new Error('Something went wrong'));
+
+  for (let i = 0; i < 10; i++) {
+    await expect(resolver.resolve()).resolves.toBe(ROOTLESS_FALLBACK);
+  }
+
+  // cached after the first failure: podmanExec should not be retried on subsequent calls
+  expect(PODMAN_WORKER_MOCK.podmanExec).toHaveBeenCalledOnce();
+});
+
+test('should not cache the fallback when cancelled, and retry on the next call', async () => {
+  const resolver = new RootlessResolver(PODMAN_WORKER_MOCK);
+  vi.mocked(PODMAN_WORKER_MOCK.podmanExec).mockRejectedValue(new Error('Something went wrong'));
+
+  const cancelledToken: CancellationToken = {
+    isCancellationRequested: true,
+    onCancellationRequested: vi.fn(),
+  };
+
+  await expect(resolver.resolve({ token: cancelledToken })).resolves.toBe(ROOTLESS_FALLBACK);
+  await expect(resolver.resolve({ token: cancelledToken })).resolves.toBe(ROOTLESS_FALLBACK);
+
+  expect(PODMAN_WORKER_MOCK.podmanExec).toHaveBeenCalledTimes(2);
 });

--- a/packages/backend/src/utils/resolvers/rootless-resolver.ts
+++ b/packages/backend/src/utils/resolvers/rootless-resolver.ts
@@ -1,0 +1,49 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import type { Resolver } from '/@/utils/resolvers/resolver';
+import type { CancellationToken, Logger } from '@podman-desktop/api';
+import type { PodmanWorker } from '/@/utils/worker/podman-worker';
+
+/**
+ * If we cannot determine the engine's privilege level, default to rootless: this matches
+ * the extension's pre-existing (rootless-only) behaviour, and avoids attempting admin-scope
+ * operations against a connection we are not sure can support them.
+ */
+export const ROOTLESS_FALLBACK = true;
+
+export class RootlessResolver implements Resolver<boolean> {
+  private cached: boolean | undefined;
+
+  constructor(private executor: PodmanWorker) {}
+
+  async resolve(options?: { token?: CancellationToken; logger?: Logger }): Promise<boolean> {
+    if (this.cached !== undefined) return this.cached;
+
+    try {
+      const result = await this.executor.podmanExec({
+        args: ['info', '--format', '{{.Host.Security.Rootless}}'],
+        ...options,
+      });
+      this.cached = result.stdout.trim() === 'true';
+      return this.cached;
+    } catch (err: unknown) {
+      console.error('something went wrong while getting the rootless status', err);
+      return ROOTLESS_FALLBACK;
+    }
+  }
+}

--- a/packages/backend/src/utils/resolvers/rootless-resolver.ts
+++ b/packages/backend/src/utils/resolvers/rootless-resolver.ts
@@ -39,10 +39,19 @@ export class RootlessResolver implements Resolver<boolean> {
         args: ['info', '--format', '{{.Host.Security.Rootless}}'],
         ...options,
       });
-      this.cached = result.stdout.trim() === 'true';
+      const rootless = result.stdout.trim();
+      if (rootless !== 'true' && rootless !== 'false') {
+        throw new Error(`unexpected rootless status: "${rootless}"`);
+      }
+      this.cached = rootless === 'true';
       return this.cached;
     } catch (err: unknown) {
       console.error('something went wrong while getting the rootless status', err);
+      // cache the fallback (unless we were cancelled) so a single collection cycle can't
+      // observe two different scopes for the same connection if a retry later succeeds
+      if (!options?.token?.isCancellationRequested) {
+        this.cached = ROOTLESS_FALLBACK;
+      }
       return ROOTLESS_FALLBACK;
     }
   }

--- a/packages/backend/src/utils/worker/podman-worker.spec.ts
+++ b/packages/backend/src/utils/worker/podman-worker.spec.ts
@@ -21,6 +21,7 @@ import { PodmanWorker } from '/@/utils/worker/podman-worker';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { QuadletBinaryResolver } from '/@/utils/resolvers/quadlet-binary-resolver';
 import { PodmanVersionResolver } from '/@/utils/resolvers/podman-version-resolver';
+import { RootlessResolver } from '/@/utils/resolvers/rootless-resolver';
 import { SemVer } from 'semver';
 
 const WSL_PROVIDER_CONNECTION_MOCK: ProviderContainerConnection = {
@@ -53,6 +54,7 @@ const QUADLET_BINARY_PATH_MOCK = '/usr/libexec/podman/quadlet';
 
 vi.mock(import('/@/utils/resolvers/quadlet-binary-resolver'));
 vi.mock(import('/@/utils/resolvers/podman-version-resolver'));
+vi.mock(import('/@/utils/resolvers/rootless-resolver'));
 
 class PodmanWorkerImpl extends PodmanWorker {
   constructor(
@@ -190,5 +192,14 @@ describe('getPodmanVersion', () => {
 
     const version = await worker.getPodmanVersion();
     expect(version.version).toBe('5.7.1');
+  });
+});
+
+describe('isRootless', () => {
+  test('should return the resolved rootless status', async () => {
+    const worker = getPodmanWorkerImpl();
+    vi.mocked(RootlessResolver.prototype.resolve).mockResolvedValue(false);
+
+    await expect(worker.isRootless()).resolves.toBe(false);
   });
 });

--- a/packages/backend/src/utils/worker/podman-worker.ts
+++ b/packages/backend/src/utils/worker/podman-worker.ts
@@ -27,15 +27,18 @@ import type { AsyncInit } from '/@/utils/async-init';
 import { isRunError } from '/@/utils/run-error';
 import { QuadletBinaryResolver } from '/@/utils/resolvers/quadlet-binary-resolver';
 import { PodmanVersionResolver } from '/@/utils/resolvers/podman-version-resolver';
+import { RootlessResolver } from '/@/utils/resolvers/rootless-resolver';
 import type { SemVer } from 'semver';
 
 export abstract class PodmanWorker implements Disposable, AsyncInit {
   protected quadletBinaryResolver: QuadletBinaryResolver;
   protected podmanVersionResolver: PodmanVersionResolver;
+  protected rootlessResolver: RootlessResolver;
 
   protected constructor(protected connection: ProviderContainerConnection) {
     this.quadletBinaryResolver = new QuadletBinaryResolver(this);
     this.podmanVersionResolver = new PodmanVersionResolver(this);
+    this.rootlessResolver = new RootlessResolver(this);
   }
 
   /**
@@ -163,6 +166,14 @@ export abstract class PodmanWorker implements Disposable, AsyncInit {
     env?: Record<string, string>;
   }): Promise<SemVer> {
     return this.podmanVersionResolver.resolve(options);
+  }
+
+  /**
+   * Whether the engine behind this connection is rootless. Used to decide, per connection,
+   * whether quadlet/systemctl operations should target the user (--user) or system-wide scope.
+   */
+  async isRootless(options?: { logger?: Logger; token?: CancellationToken }): Promise<boolean> {
+    return this.rootlessResolver.resolve(options);
   }
 
   /**

--- a/packages/shared/src/models/base-quadlet.ts
+++ b/packages/shared/src/models/base-quadlet.ts
@@ -53,4 +53,10 @@ export interface BaseQuadlet {
    * A Quadlet can have files associated with them (E.g., Yaml= for Kube Quadlet)
    */
   files: Array<FileReference>;
+  /**
+   * true if this is a system-wide (rootful) quadlet, managed with `systemctl`/`quadlet -dryrun` (no `-user`).
+   * false/undefined if it is a user (rootless) quadlet, managed with `systemctl --user`/`quadlet -dryrun -user`.
+   * @default false
+   */
+  admin?: boolean;
 }


### PR DESCRIPTION
## Summary

Quadlet discovery always ran `quadlet -dryrun -user`, so system-wide (rootful)
quadlets under `/etc/containers/systemd` were invisible on rootful connections
(e.g. `ssh://root@host/run/podman/podman.sock`). Only the "create new quadlet"
write path had a working admin toggle — discovery, status refresh,
start/stop/restart, remove, and log following were all hardcoded to the
rootless (`--user`) scope.

Each connection now queries whichever scope actually matches its engine,
instead of always assuming rootless. A new `RootlessResolver` asks the
connection itself (`podman info --format '{{.Host.Security.Rootless}}'`,
cached per connection, works for native/SSH/machine connections alike)
whether it's rootless or rootful, and only that matching scope is collected.
This mirrors how the Containers page already behaves — one connection, one
privilege scope, never mixed — so a plain local rootless connection keeps
working exactly as it does today, with no duplicate or degraded entries.

- Quadlet objects are tagged with the scope (`admin`) they were collected
  from, so per-quadlet actions dispatch in the right mode.
- `collectPodmanQuadlet` / `refreshQuadletsStatuses` each check the
  connection's scope once (cached) instead of guessing or querying both.
- `remove()` reloads the daemon in the connection's actual scope.
- `start`/`stop`/`restart`/`createQuadletLogger` use the quadlet's own scope
  instead of being hardcoded to rootless.

## AI assistance disclosure

The implementation (code + tests) and this PR description were written with
assistance from Claude (Anthropic), working under my direction — I reviewed,
tested, and take responsibility for the change. Commits are signed off
accordingly (`Assisted-by: Claude (Anthropic)`).

## Testing

- Added/updated unit tests for `RootlessResolver`, `PodmanWorker#isRootless`,
  and the scope-selection logic in `QuadletService` / `QuadletApiImpl` —
  503/503 passing.
- `pnpm format:check`, `pnpm lint:check`, `pnpm typecheck`, `pnpm build` all
  clean.
- Manually verified against two real rootful SSH connections
  (`ssh://root@host/run/podman/podman.sock`) alongside the default local
  rootless connection. Screenshot below: quadlets correctly listed and
  tagged per connection (`Local-Root`, `Rampage-Root`, plain `Podman`), no
  duplicates, no regression on the rootless connection.

<img width="2560" height="1408" alt="root-quadlet-screenshot" src="https://github.com/user-attachments/assets/1ebfb933-5cf2-4632-8f82-0afe0317481c" />


## Notes for reviewers

- Only tested on Linux against Linux SSH targets — didn't have a Windows/macOS
  Podman Machine on hand to verify against, though the `Host.Security.Rootless`
  check is generic and should behave the same there.
- No dedicated e2e scenario added for rootful quadlets; happy to add one if
  that's expected before merge.