### PR TITLE
fix: svelte-select v6

### DIFF
--- a/packages/frontend/src/lib/select/ContainerProviderConnectionSelect.svelte
+++ b/packages/frontend/src/lib/select/ContainerProviderConnectionSelect.svelte
@@ -55,7 +55,7 @@ function getProviderStatusColor(item: ProviderContainerConnectionDetailedInfo): 
     value: containerProviderConnection.name,
     label: containerProviderConnection.name,
   }))}>
-  <div slot="item" let:item>
+  {#snippet item({ item })}
     <div class="flex items-center">
       <div class="flex w-2 h-2 me-2 rounded-full {getProviderStatusColor(item)}"></div>
       <div class="grow">
@@ -66,5 +66,5 @@ function getProviderStatusColor(item: ProviderContainerConnectionDetailedInfo): 
         <div>({item.vmType})</div>
       {/if}
     </div>
-  </div>
+  {/snippet}
 </Select>

--- a/packages/frontend/src/lib/select/ContainersSelect.svelte
+++ b/packages/frontend/src/lib/select/ContainersSelect.svelte
@@ -40,12 +40,12 @@ function handleOnChange(nValue: SimpleContainerInfo | undefined): void {
     value: container.name,
     label: container.name,
   }))}>
-  <div slot="item" let:item>
+  {#snippet item({ item })}
     <div class="flex items-center">
       <ContainerStateIndicator state={item.state} />
       <div class="grow">
         <span>{item.name.substring(1)}</span>
       </div>
     </div>
-  </div>
+  {/snippet}
 </Select>

--- a/packages/frontend/src/lib/select/ImagesSelect.svelte
+++ b/packages/frontend/src/lib/select/ImagesSelect.svelte
@@ -39,11 +39,11 @@ function handleOnChange(nValue: SimpleImageInfo | undefined): void {
     value: image.name,
     label: image.name,
   }))}>
-  <div slot="item" let:item>
+  {#snippet item({ item })}
     <div class="flex items-center">
       <div class="grow">
         <span>{item.name}</span>
       </div>
     </div>
-  </div>
+  {/snippet}
 </Select>

--- a/packages/frontend/src/lib/select/PodsSelect.svelte
+++ b/packages/frontend/src/lib/select/PodsSelect.svelte
@@ -40,7 +40,7 @@ function handleOnChange(nValue: SimplePodInfo | undefined): void {
     value: pod.name,
     label: pod.name,
   }))}>
-  <div slot="item" let:item>
+  {#snippet item({ item })}
     <div class="flex flex-row items-center">
       <span class="grow">{item.name}</span>
       <div class="flex flex-row gap-x-1">
@@ -49,5 +49,5 @@ function handleOnChange(nValue: SimplePodInfo | undefined): void {
         {/each}
       </div>
     </div>
-  </div>
+  {/snippet}
 </Select>

--- a/packages/frontend/src/lib/select/Select.svelte
+++ b/packages/frontend/src/lib/select/Select.svelte
@@ -1,19 +1,33 @@
-<script lang="ts">
+<script lang="ts" generics="T extends { label: string; value: string }">
 import Select from 'svelte-select';
+import type { Snippet } from 'svelte';
 
-type T = $$Generic<{ label: string; value: string }>;
-export let disabled: boolean = false;
+interface Props {
+  disabled?: boolean;
+  value?: T;
+  items: T[];
+  placeholder?: string;
+  label?: string;
+  name?: string;
+  onchange?: (value: T | undefined) => void;
+  clearable?: boolean;
+  item?: Snippet<[{ item: T }]>;
+}
 
-export let value: T | undefined = undefined;
-export let items: T[] = [];
-export let placeholder: string | undefined = undefined;
-export let label: string | undefined = undefined;
-export let name: string | undefined = undefined;
-export let onchange: ((value: T | undefined) => void) | undefined = undefined;
-export let clearable: boolean = true;
+let {
+  disabled = false,
+  items = [],
+  item: itemSnippet,
+  value = $bindable(),
+  placeholder,
+  label,
+  name,
+  onchange,
+  clearable = true,
+}: Props = $props();
 
-function handleOnChange(e: CustomEvent<T | undefined>): void {
-  value = e.detail;
+function handleOnChange(item: T): void {
+  value = item;
   onchange?.(value);
 }
 
@@ -23,13 +37,17 @@ function handleOnClear(): void {
 }
 </script>
 
+{#snippet item({ item }: { item: { label: string; value: string } })}
+  <div>{item.label}</div>
+{/snippet}
+
 <Select
   inputAttributes={{ 'aria-label': label }}
   name={name}
   disabled={disabled}
   value={value}
-  on:clear={handleOnClear}
-  on:change={handleOnChange}
+  onclear={handleOnClear}
+  onchange={handleOnChange}
   --item-color="var(--pd-dropdown-item-text)"
   --item-is-active-color="var(--pd-dropdown-item-text)"
   --item-hover-color="var(--pd-dropdown-item-hover-text)"
@@ -56,10 +74,5 @@ function handleOnClear(): void {
   clearable={clearable}
   class="!bg-[var(--pd-content-bg)] !text-[var(--pd-content-card-text)]"
   items={items}
-  showChevron={!disabled}>
-  <div slot="item" let:item>
-    <slot name="item" item={item}>
-      <div>{item.label}</div>
-    </slot>
-  </div>
-</Select>
+  showChevron={!disabled}
+  item={(itemSnippet ?? item) as Snippet<[{ item: Record<string, unknown> }]>} />


### PR DESCRIPTION
## Description

:warning: this PR target https://github.com/podman-desktop/extension-podman-quadlet/pull/1710

The svelte-select library has migrated to Svelte 5 making some breaking change, thanks the CI has caught it, and dependabot update need some fixing

## Testing manually

Go to the Quadlet Generate page
Test all the selects

https://github.com/user-attachments/assets/e09e10c5-408a-4cb9-874d-30e4b1326498

