### PR TITLE
chore(deps): bump @podman-desktop/podman-extension-api to 1.29.1

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -77,7 +77,7 @@
   "devDependencies": {
     "@podman-desktop/quadlet-extension-core-api": "workspace:^",
     "@podman-desktop/api": "^1.29.1",
-    "@podman-desktop/podman-extension-api": "^1.28.2",
+    "@podman-desktop/podman-extension-api": "^1.29.1",
     "@types/node": "^24",
     "@types/ssh2": "^1.15.5",
     "@types/ssh2-sftp-client": "^9.0.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,8 +146,8 @@ importers:
         specifier: ^1.29.1
         version: 1.29.1
       '@podman-desktop/podman-extension-api':
-        specifier: ^1.28.2
-        version: 1.28.3
+        specifier: ^1.29.1
+        version: 1.29.1
       '@podman-desktop/quadlet-extension-core-api':
         specifier: workspace:^
         version: link:../shared
@@ -875,14 +875,11 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  '@podman-desktop/api@1.28.3':
-    resolution: {integrity: sha512-RCYrD90VfVn59oa8vTaDXj8Qy9BD0jxyiTNBhKNcloYf1hBCDMIKgqTcXYgNq15/5P1aGjRmgaG/jnhDEuux/g==}
-
   '@podman-desktop/api@1.29.1':
     resolution: {integrity: sha512-UtCY2t5hVLz5pHXSV5DmQESPLUqSxDgKhJfqlQ4GO7L0x/fQdaX22KGbuzOEUSs1KzB0nwWNB3ylaTcE/OBdZA==}
 
-  '@podman-desktop/podman-extension-api@1.28.3':
-    resolution: {integrity: sha512-j9OwVI3uN9nxLDtSwKwak8Xgw7TWRV0nlxm/Kop1OFv+EJF7Nb+0wXL8A6z011hA86XKWg7wFAF3HXS5hflZqw==}
+  '@podman-desktop/podman-extension-api@1.29.1':
+    resolution: {integrity: sha512-jB6oC97jyEUWIRyovCVShwRVjJbsJecs6qrDnMRkpRzP9RTChRXDZqdoenLmA5WKXpUC0++CXDerNIWopYIfJQ==}
 
   '@podman-desktop/tests-playwright@1.29.1':
     resolution: {integrity: sha512-MS2rXf3hnCTxykyAJ6BfU2OC38+vElcwPHWAT4dIEhWslZ77LEIytO1ym+6AsefsCql9rTUBEj26oSN6r3Dg0Q==}
@@ -4649,13 +4646,11 @@ snapshots:
     dependencies:
       playwright: 1.57.0
 
-  '@podman-desktop/api@1.28.3': {}
-
   '@podman-desktop/api@1.29.1': {}
 
-  '@podman-desktop/podman-extension-api@1.28.3':
+  '@podman-desktop/podman-extension-api@1.29.1':
     dependencies:
-      '@podman-desktop/api': 1.28.3
+      '@podman-desktop/api': 1.29.1
 
   '@podman-desktop/tests-playwright@1.29.1': {}
 


### PR DESCRIPTION
## Description

Update `@podman-desktop/podman-extension-api` to 1.29.1

## Related issue

Required for
- https://github.com/podman-desktop/extension-podman-quadlet/pull/1714