### PR TITLE
fix(ci): use pnpm why for getting @podman-desktop/api correctly

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -102,7 +102,7 @@ jobs:
         shell: bash
         run: |
           # Using pnpm list to get the resolved version (E.g. getting 1.15.0 when ^1.15.0)
-          export PD_VERSION=$(pnpm why -C packages/backend "@podman-desktop/api" --json | jq .[0].version)
+          export PD_VERSION=$(pnpm why -C packages/backend "@podman-desktop/api" --json | jq '.[0].devDependencies."@podman-desktop/api".version')
           echo "PD_VERSION=$PD_VERSION" >> $GITHUB_OUTPUT
           echo "Using @podman-desktop/api $PD_VERSION"
 

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -102,7 +102,7 @@ jobs:
         shell: bash
         run: |
           # Using pnpm list to get the resolved version (E.g. getting 1.15.0 when ^1.15.0)
-          export PD_VERSION=$(pnpm list -C packages/backend/ --json | jq -r '.[0].devDependencies."@podman-desktop/api".version')
+          export PD_VERSION=$(pnpm why -C packages/backend "@podman-desktop/api" --json | jq .[0].version)
           echo "PD_VERSION=$PD_VERSION" >> $GITHUB_OUTPUT
           echo "Using @podman-desktop/api $PD_VERSION"
 

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -102,7 +102,7 @@ jobs:
         shell: bash
         run: |
           # Using pnpm list to get the resolved version (E.g. getting 1.15.0 when ^1.15.0)
-          export PD_VERSION=$(pnpm why -C packages/backend "@podman-desktop/api" --json | jq '.[0].devDependencies."@podman-desktop/api".version')
+          export PD_VERSION=$(pnpm why -C packages/backend "@podman-desktop/api" --json | jq -r '.[0].devDependencies."@podman-desktop/api".version')
           echo "PD_VERSION=$PD_VERSION" >> $GITHUB_OUTPUT
           echo "Using @podman-desktop/api $PD_VERSION"
 


### PR DESCRIPTION
## Description

The `pnpm list` change their behavior in pnpm v11 breaking the migration to pnpm v11 (See https://github.com/podman-desktop/extension-podman-quadlet/pull/1714)

## Related issues

Required for https://github.com/podman-desktop/extension-podman-quadlet/pull/1714