### PR TITLE
fix: resolve GHSA-55q2-fjhq-7xh7 in dompurify

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
   minimatch@>=9.0.0 <9.0.6: 9.0.9
   lodash@>=4.0.0 <=4.17.23: '>=4.18.0'
   ajv@>=8.0.0 <8.18.0: 8.18.0
-  dompurify@<=3.4.11: '>=3.4.12'
+  dompurify@<=3.4.12: '>=3.4.13'
   brace-expansion@^1: ^1.1.18
   brace-expansion@^2: ^2.1.4
   brace-expansion@^5: ^5.0.9
@@ -2007,8 +2007,8 @@ packages:
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
-  dompurify@3.4.12:
-    resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
+  dompurify@3.4.13:
+    resolution: {integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -5776,7 +5776,7 @@ snapshots:
 
   dom-accessibility-api@0.6.3: {}
 
-  dompurify@3.4.12:
+  dompurify@3.4.13:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -6855,7 +6855,7 @@ snapshots:
 
   monaco-editor@0.55.1:
     dependencies:
-      dompurify: 3.4.12
+      dompurify: 3.4.13
       marked: 14.0.0
 
   mri@1.2.0: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,7 +8,7 @@ overrides:
   minimatch@>=9.0.0 <9.0.6: 9.0.9
   lodash@>=4.0.0 <=4.17.23: '>=4.18.0'
   ajv@>=8.0.0 <8.18.0: 8.18.0
-  dompurify@<=3.4.11: '>=3.4.12'
+  dompurify@<=3.4.12: '>=3.4.13'
   brace-expansion@^1: ^1.1.18
   brace-expansion@^2: ^2.1.4
   brace-expansion@^5: ^5.0.9


### PR DESCRIPTION
### What does this PR do?

Fix moderate severity vulnerability GHSA-55q2-fjhq-7xh7 in `dompurify`.

**Advisory**: DOMPurify: IN_PLACE hook removal leaves a detached subtree executable, causing XSS
**Vulnerable versions**: <=3.4.12
**Patched versions**: >=3.4.13
**Advisory URL**: https://github.com/advisories/GHSA-55q2-fjhq-7xh7

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes GHSA-55q2-fjhq-7xh7: _DOMPurify: IN_PLACE hook removal leaves a detached subtree executable, causing XSS_

### How to test this PR?

Run `pnpm audit` and verify GHSA-55q2-fjhq-7xh7 is no longer reported