### PR TITLE
chore: updating ubuntu runner to 26.04

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -34,7 +34,7 @@ jobs:
   # Dedicated step to build the quadlet extension image
   build-container:
     name: Build Extension Image
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Build Image and Extract Files
@@ -59,7 +59,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ windows-2025, ubuntu-24.04 ]
+        os: [ windows-2025, ubuntu-26.04 ]
     env:
       SKIP_INSTALLATION: true
       EXTENSION_PREINSTALLED: true
@@ -68,15 +68,6 @@ jobs:
       PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/podman-desktop/pw-browsers
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      # ==============================================
-      # Installing Podman
-      # ==============================================
-      - name: Install Podman
-        uses: redhat-actions/podman-install@aea6ff44f2a4a82da13d22061ce73443a125925d
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          ubuntu-version: '24.04'
 
       # ==============================================
       # Installing Podman Desktop

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -29,7 +29,7 @@ concurrency:
 jobs:
   lint-format-typecheck:
     name: linter, formatters
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
@@ -65,7 +65,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [windows-2025, ubuntu-24.04, macos-15]
+        os: [windows-2025, ubuntu-26.04, macos-15]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -90,7 +90,7 @@ jobs:
 
   build-oci:
     name: build oci image
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     outputs:
       artifact-id: ${{ steps.build.outputs.artifact-id }}
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,7 +37,7 @@ jobs:
 
   tag:
     name: Tagging
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     permissions:
       contents: write
       pull-requests: write
@@ -128,7 +128,7 @@ jobs:
 
   build:
     needs: [tag]
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     permissions:
       contents: read
       packages: write
@@ -151,7 +151,7 @@ jobs:
   release:
     needs: [tag, build]
     name: Release
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
## Description

Trying to bump the ubuntu runner to 26.04

:warning: the `redhat-actions/podman-install` action where installing podman 5, but now with the ubuntu-26.04 runner is already shipping podman v5 