### PR TITLE
fix: resolve GHSA-5jgf-p345-68v8 in fast-uri

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,7 @@ overrides:
   undici@<6.27.0: ^6.27.0
   undici@>=7.23.0 <7.28.0: ^7.28.0
   browserslist@<=4.28.6: '>=4.28.7'
+  fast-uri@>=3.1.3 <4: ^3.1.6
 
 importers:
 
@@ -2308,8 +2309,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.7:
+    resolution: {integrity: sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==}
 
   fastq@1.20.2:
     resolution: {integrity: sha512-UpGiiODyCGprM8EPP6JodP6jC9Rws6TCuiDOD+nn0CJhR8guI3g/ozo4ugL0vJ+Yz1UtJuuRPqvQuybVOF1VQA==}
@@ -5399,7 +5400,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.7
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
     optional: true
@@ -6189,7 +6190,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.5:
+  fast-uri@3.1.7:
     optional: true
 
   fastq@1.20.2:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,6 +22,7 @@ overrides:
   undici@<6.27.0: ^6.27.0
   undici@>=7.23.0 <7.28.0: ^7.28.0
   browserslist@<=4.28.6: '>=4.28.7'
+  fast-uri@>=3.1.3 <4: ^3.1.6
 nodeLinker: hoisted
 allowBuilds:
   cpu-features: true


### PR DESCRIPTION
### What does this PR do?

Fix high severity vulnerability GHSA-5jgf-p345-68v8 in `fast-uri`.

**Advisory**: fast-uri vulnerable to host confusion via skipped IDN canonicalization on scheme-relative references
**Vulnerable versions**: >=3.1.3 <3.1.6
**Patched versions**: >=3.1.6
**Advisory URL**: https://github.com/advisories/GHSA-5jgf-p345-68v8

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes GHSA-5jgf-p345-68v8: _fast-uri vulnerable to host confusion via skipped IDN canonicalization on scheme-relative references_

### How to test this PR?

Run `pnpm audit` and verify GHSA-5jgf-p345-68v8 is no longer reported